### PR TITLE
Mark main entry points as #[inline].

### DIFF
--- a/inlining/expected-methods-x86-nostd-avx2.txt
+++ b/inlining/expected-methods-x86-nostd-avx2.txt
@@ -4,8 +4,6 @@
 <simdutf8::compat::Utf8Error as core::fmt::Debug>::fmt
 <simdutf8::compat::Utf8Error as core::fmt::Display>::fmt
 core::ptr::drop_in_place<&u8>
-simdutf8::basic::from_utf8
-simdutf8::basic::from_utf8_mut
-simdutf8::compat::from_utf8
-simdutf8::compat::from_utf8_mut
 simdutf8::implementation::get_compat_error
+simdutf8::implementation::x86::validate_utf8_basic
+simdutf8::implementation::x86::validate_utf8_compat

--- a/inlining/expected-methods-x86-nostd-fallback.txt
+++ b/inlining/expected-methods-x86-nostd-fallback.txt
@@ -3,7 +3,3 @@
 <simdutf8::compat::Utf8Error as core::fmt::Debug>::fmt
 <simdutf8::compat::Utf8Error as core::fmt::Display>::fmt
 core::ptr::drop_in_place<&u8>
-simdutf8::basic::from_utf8
-simdutf8::basic::from_utf8_mut
-simdutf8::compat::from_utf8
-simdutf8::compat::from_utf8_mut

--- a/inlining/expected-methods-x86-nostd-sse42.txt
+++ b/inlining/expected-methods-x86-nostd-sse42.txt
@@ -4,8 +4,6 @@
 <simdutf8::compat::Utf8Error as core::fmt::Debug>::fmt
 <simdutf8::compat::Utf8Error as core::fmt::Display>::fmt
 core::ptr::drop_in_place<&u8>
-simdutf8::basic::from_utf8
-simdutf8::basic::from_utf8_mut
-simdutf8::compat::from_utf8
-simdutf8::compat::from_utf8_mut
 simdutf8::implementation::get_compat_error
+simdutf8::implementation::x86::validate_utf8_basic
+simdutf8::implementation::x86::validate_utf8_compat

--- a/inlining/expected-methods-x86-std-avx2.txt
+++ b/inlining/expected-methods-x86-std-avx2.txt
@@ -4,8 +4,6 @@
 <simdutf8::compat::Utf8Error as core::fmt::Debug>::fmt
 <simdutf8::compat::Utf8Error as core::fmt::Display>::fmt
 core::ptr::drop_in_place<&u8>
-simdutf8::basic::from_utf8
-simdutf8::basic::from_utf8_mut
-simdutf8::compat::from_utf8
-simdutf8::compat::from_utf8_mut
 simdutf8::implementation::get_compat_error
+simdutf8::implementation::x86::validate_utf8_basic
+simdutf8::implementation::x86::validate_utf8_compat

--- a/inlining/expected-methods-x86-std.txt
+++ b/inlining/expected-methods-x86-std.txt
@@ -4,10 +4,6 @@
 <simdutf8::compat::Utf8Error as core::fmt::Debug>::fmt
 <simdutf8::compat::Utf8Error as core::fmt::Display>::fmt
 core::ptr::drop_in_place<&u8>
-simdutf8::basic::from_utf8
-simdutf8::basic::from_utf8_mut
-simdutf8::compat::from_utf8
-simdutf8::compat::from_utf8_mut
 simdutf8::implementation::get_compat_error
 simdutf8::implementation::validate_utf8_basic_fallback
 simdutf8::implementation::validate_utf8_compat_fallback

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -23,6 +23,7 @@ pub struct Utf8Error {}
 ///
 /// # Errors
 /// Will return the zero-sized Err([`Utf8Error`]) on if the input contains invalid UTF-8.
+#[inline]
 pub fn from_utf8(input: &[u8]) -> Result<&str, Utf8Error> {
     unsafe {
         validate_utf8_basic(input)?;
@@ -37,6 +38,7 @@ pub fn from_utf8(input: &[u8]) -> Result<&str, Utf8Error> {
 ///
 /// # Errors
 /// Will return the zero-sized Err([`Utf8Error`]) on if the input contains invalid UTF-8.
+#[inline]
 pub fn from_utf8_mut(input: &mut [u8]) -> Result<&mut str, Utf8Error> {
     unsafe {
         validate_utf8_basic(input)?;

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -72,6 +72,7 @@ impl Display for Utf8Error {
 /// # Errors
 /// Will return Err([`Utf8Error`]) on if the input contains invalid UTF-8 with
 /// detailed error information.
+#[inline]
 pub fn from_utf8(input: &[u8]) -> Result<&str, Utf8Error> {
     unsafe {
         validate_utf8_compat(input)?;
@@ -87,6 +88,7 @@ pub fn from_utf8(input: &[u8]) -> Result<&str, Utf8Error> {
 /// # Errors
 /// Will return Err([`Utf8Error`]) on if the input contains invalid UTF-8 with
 /// detailed error information.
+#[inline]
 pub fn from_utf8_mut(input: &mut [u8]) -> Result<&mut str, Utf8Error> {
     unsafe {
         validate_utf8_compat(input)?;

--- a/src/implementation/x86/mod.rs
+++ b/src/implementation/x86/mod.rs
@@ -43,14 +43,22 @@ fn get_fastest_available_implementation_basic() -> super::ValidateUtf8Fn {
 // validate_utf8_basic() no-std: implementation selection by config
 
 #[cfg(target_feature = "avx2")]
-pub(crate) use avx2::validate_utf8_basic;
+pub(crate) unsafe fn validate_utf8_basic(
+    input: &[u8],
+) -> core::result::Result<(), crate::basic::Utf8Error> {
+    avx2::validate_utf8_basic(input)
+}
 
 #[cfg(all(
     not(feature = "std"),
     not(target_feature = "avx2"),
     target_feature = "sse4.2"
 ))]
-pub(crate) use sse42::validate_utf8_basic;
+pub(crate) unsafe fn validate_utf8_basic(
+    input: &[u8],
+) -> core::result::Result<(), crate::basic::Utf8Error> {
+    sse42::validate_utf8_basic(input)
+}
 
 #[cfg(all(
     not(feature = "std"),
@@ -99,14 +107,22 @@ fn get_fastest_available_implementation_compat() -> super::ValidateUtf8CompatFn 
 // validate_utf8_basic() no-std: implementation selection by config
 
 #[cfg(target_feature = "avx2")]
-pub(crate) use avx2::validate_utf8_compat;
+pub(crate) unsafe fn validate_utf8_compat(
+    input: &[u8],
+) -> core::result::Result<(), crate::compat::Utf8Error> {
+    avx2::validate_utf8_compat(input)
+}
 
 #[cfg(all(
     not(feature = "std"),
     not(target_feature = "avx2"),
     target_feature = "sse4.2"
 ))]
-pub(crate) use sse42::validate_utf8_compat;
+pub(crate) unsafe fn validate_utf8_compat(
+    input: &[u8],
+) -> core::result::Result<(), crate::compat::Utf8Error> {
+    sse42::validate_utf8_compat(input)
+}
 
 #[cfg(all(
     not(feature = "std"),


### PR DESCRIPTION
This is the first step towards fixing slowness on small inputs (#4).

Further code changes were necessary so that inlining is only done for the fn using auto-detection and the fallback fn.