### PR TITLE
Remove internal memcpy implementation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,6 +19,7 @@
   * broadcast() -> splat()
   * indirection functions
   * self first always
+  * const?
 
 # OTHER
 * why does cargo asm not find from_utf8() on aarch64?

--- a/src/implementation/algorithm.rs
+++ b/src/implementation/algorithm.rs
@@ -240,7 +240,7 @@ macro_rules! algorithm_simd {
                 let off = (input.as_ptr() as usize) % align;
                 if off != 0 {
                     let to_copy = align - off;
-                    crate::implementation::helpers::memcpy_unaligned_nonoverlapping_inline(
+                    crate::implementation::helpers::memcpy_unaligned_nonoverlapping_inline_opt_lt_64(
                         input.as_ptr(),
                         tmpbuf.0[SIMD_CHUNK_SIZE - align + off..].as_mut_ptr(),
                         to_copy,
@@ -260,7 +260,7 @@ macro_rules! algorithm_simd {
             }
 
             if idx < len {
-                crate::implementation::helpers::memcpy_unaligned_nonoverlapping_inline(
+                crate::implementation::helpers::memcpy_unaligned_nonoverlapping_inline_opt_lt_64(
                     input.as_ptr().add(idx),
                     tmpbuf.1.as_mut_ptr(),
                     len - idx,
@@ -309,7 +309,7 @@ macro_rules! algorithm_simd {
                 let off = (input.as_ptr() as usize) % align;
                 if off != 0 {
                     let to_copy = align - off;
-                    crate::implementation::helpers::memcpy_unaligned_nonoverlapping_inline(
+                    crate::implementation::helpers::memcpy_unaligned_nonoverlapping_inline_opt_lt_64(
                         input.as_ptr(),
                         tmpbuf.0[SIMD_CHUNK_SIZE - align + off..].as_mut_ptr(),
                         to_copy,
@@ -334,7 +334,7 @@ macro_rules! algorithm_simd {
                 idx += SIMD_CHUNK_SIZE;
             }
             if idx < len {
-                crate::implementation::helpers::memcpy_unaligned_nonoverlapping_inline(
+                crate::implementation::helpers::memcpy_unaligned_nonoverlapping_inline_opt_lt_64(
                     input.as_ptr().add(idx),
                     tmpbuf.1.as_mut_ptr(),
                     len - idx,

--- a/src/implementation/algorithm.rs
+++ b/src/implementation/algorithm.rs
@@ -240,11 +240,9 @@ macro_rules! algorithm_simd {
                 let off = (input.as_ptr() as usize) % align;
                 if off != 0 {
                     let to_copy = align - off;
-                    crate::implementation::helpers::memcpy_unaligned_nonoverlapping_inline_opt_lt_64(
-                        input.as_ptr(),
-                        tmpbuf.0[SIMD_CHUNK_SIZE - align + off..].as_mut_ptr(),
-                        to_copy,
-                    );
+                    tmpbuf.0[SIMD_CHUNK_SIZE - align + off..]
+                        .as_mut_ptr()
+                        .copy_from_nonoverlapping(input.as_ptr(), to_copy);
                     let simd_input = SimdInput::new(&tmpbuf.0);
                     algorithm.check_utf8(simd_input);
                     idx += to_copy;
@@ -260,11 +258,10 @@ macro_rules! algorithm_simd {
             }
 
             if idx < len {
-                crate::implementation::helpers::memcpy_unaligned_nonoverlapping_inline_opt_lt_64(
-                    input.as_ptr().add(idx),
-                    tmpbuf.1.as_mut_ptr(),
-                    len - idx,
-                );
+                tmpbuf
+                    .1
+                    .as_mut_ptr()
+                    .copy_from_nonoverlapping(input.as_ptr().add(idx), len - idx);
                 let input = SimdInput::new(&tmpbuf.1);
 
                 algorithm.check_utf8(input);
@@ -309,11 +306,9 @@ macro_rules! algorithm_simd {
                 let off = (input.as_ptr() as usize) % align;
                 if off != 0 {
                     let to_copy = align - off;
-                    crate::implementation::helpers::memcpy_unaligned_nonoverlapping_inline_opt_lt_64(
-                        input.as_ptr(),
-                        tmpbuf.0[SIMD_CHUNK_SIZE - align + off..].as_mut_ptr(),
-                        to_copy,
-                    );
+                    tmpbuf.0[SIMD_CHUNK_SIZE - align + off..]
+                        .as_mut_ptr()
+                        .copy_from_nonoverlapping(input.as_ptr(), to_copy);
                     let simd_input = SimdInput::new(&tmpbuf.0);
                     algorithm.check_utf8(simd_input);
                     if algorithm.has_error() {
@@ -334,11 +329,10 @@ macro_rules! algorithm_simd {
                 idx += SIMD_CHUNK_SIZE;
             }
             if idx < len {
-                crate::implementation::helpers::memcpy_unaligned_nonoverlapping_inline_opt_lt_64(
-                    input.as_ptr().add(idx),
-                    tmpbuf.1.as_mut_ptr(),
-                    len - idx,
-                );
+                tmpbuf
+                    .1
+                    .as_mut_ptr()
+                    .copy_from_nonoverlapping(input.as_ptr().add(idx), len - idx);
                 let simd_input = SimdInput::new(&tmpbuf.1);
 
                 algorithm.check_utf8(simd_input);

--- a/src/implementation/helpers.rs
+++ b/src/implementation/helpers.rs
@@ -37,46 +37,6 @@ pub(crate) fn get_compat_error(input: &[u8], failing_block_pos: usize) -> Utf8Er
     validate_utf8_at_offset(input, offset).unwrap_err()
 }
 
-#[allow(dead_code)]
-#[allow(clippy::missing_const_for_fn)] // clippy is wrong, it cannot really be const
-pub(crate) unsafe fn memcpy_unaligned_nonoverlapping_inline_opt_lt_64(
-    mut src: *const u8,
-    mut dest: *mut u8,
-    mut len: usize,
-) {
-    // This gets properly auto-vectorized on AVX 2 and SSE 4.2
-    #[inline]
-    unsafe fn memcpy_long(src: &mut *const u8, dest: &mut *mut u8) {
-        #[allow(clippy::cast_ptr_alignment)]
-        dest.cast::<u64>()
-            .write_unaligned(src.cast::<u64>().read_unaligned());
-        *src = src.offset(8);
-        *dest = dest.offset(8);
-    }
-    if len >= 32 {
-        memcpy_long(&mut src, &mut dest);
-        memcpy_long(&mut src, &mut dest);
-        memcpy_long(&mut src, &mut dest);
-        memcpy_long(&mut src, &mut dest);
-        len -= 32;
-    }
-    if len >= 16 {
-        memcpy_long(&mut src, &mut dest);
-        memcpy_long(&mut src, &mut dest);
-        len -= 16;
-    }
-    if len >= 8 {
-        memcpy_long(&mut src, &mut dest);
-        len -= 8;
-    }
-    while len > 0 {
-        *dest = *src;
-        src = src.offset(1);
-        dest = dest.offset(1);
-        len -= 1;
-    }
-}
-
 pub(crate) const SIMD_CHUNK_SIZE: usize = 64;
 
 #[repr(C, align(32))]


### PR DESCRIPTION
LLVM is unrolling it for the 128+ bytes case which never happens. The speedup with this patch is negligable but code size is reduced quite a bit.

It is a shame that all attempts to do this the Rust way (using `copy_from_slice()` or `read_unaligned()`/`write_unaligned()`) have resulted in non-inlined calls to memcpy with noticable slowdown.

This implementation is optimally auto-vectorized and inlined. The compiler can even prove that the len is less < 32 at the first call site and optimizes that check away.