### PR TITLE
Updates for neon

### DIFF
--- a/src/implementation/aarch64/neon.rs
+++ b/src/implementation/aarch64/neon.rs
@@ -217,13 +217,14 @@ impl From<uint8x16_t> for SimdU8Value {
     }
 }
 
-#[cfg_attr(not(target_arch="aarch64"), target_feature(enable = $feat))]
-#[inline]
-unsafe fn must_be_2_3_continuation(prev2: SimdU8Value, prev3: SimdU8Value) -> SimdU8Value {
-    let is_third_byte = prev2.unsigned_gt(SimdU8Value::splat(0b1110_0000 - 1));
-    let is_fourth_byte = prev3.unsigned_gt(SimdU8Value::splat(0b1111_0000 - 1));
+impl Utf8CheckAlgorithm<SimdU8Value> {
+    #[inline]
+    unsafe fn must_be_2_3_continuation(prev2: SimdU8Value, prev3: SimdU8Value) -> SimdU8Value {
+        let is_third_byte = prev2.unsigned_gt(SimdU8Value::splat(0b1110_0000 - 1));
+        let is_fourth_byte = prev3.unsigned_gt(SimdU8Value::splat(0b1111_0000 - 1));
 
-    is_third_byte.or(is_fourth_byte)
+        is_third_byte.or(is_fourth_byte)
+    }
 }
 
 use crate::implementation::helpers::Temp2xSimdChunkA16 as Temp2xSimdChunk;

--- a/src/implementation/aarch64/neon.rs
+++ b/src/implementation/aarch64/neon.rs
@@ -195,7 +195,7 @@ impl SimdU8Value {
     }
 
     #[inline]
-    unsafe fn gt(self, other: Self) -> Self {
+    unsafe fn unsigned_gt(self, other: Self) -> Self {
         Self::from(vcgtq_u8(self.0, other.0))
     }
 
@@ -215,6 +215,15 @@ impl From<uint8x16_t> for SimdU8Value {
     fn from(val: uint8x16_t) -> Self {
         Self { 0: val }
     }
+}
+
+#[cfg_attr(not(target_arch="aarch64"), target_feature(enable = $feat))]
+#[inline]
+unsafe fn must_be_2_3_continuation(prev2: SimdU8Value, prev3: SimdU8Value) -> SimdU8Value {
+    let is_third_byte = prev2.unsigned_gt(SimdU8Value::splat(0b1110_0000 - 1));
+    let is_fourth_byte = prev3.unsigned_gt(SimdU8Value::splat(0b1111_0000 - 1));
+
+    is_third_byte.or(is_fourth_byte)
 }
 
 use crate::implementation::helpers::Temp2xSimdChunkA16 as Temp2xSimdChunk;

--- a/src/implementation/aarch64/neon.rs
+++ b/src/implementation/aarch64/neon.rs
@@ -227,6 +227,7 @@ impl Utf8CheckAlgorithm<SimdU8Value> {
     }
 }
 
+const ALIGN_READS: bool = false;
 use crate::implementation::helpers::Temp2xSimdChunkA16 as Temp2xSimdChunk;
 simd_input_128_bit!("not_used");
 algorithm_simd!("not_used");

--- a/src/implementation/algorithm.rs
+++ b/src/implementation/algorithm.rs
@@ -152,18 +152,6 @@ macro_rules! algorithm_simd {
 
             #[cfg_attr(not(target_arch="aarch64"), target_feature(enable = $feat))]
             #[inline]
-            unsafe fn must_be_2_3_continuation(
-                prev2: SimdU8Value,
-                prev3: SimdU8Value,
-            ) -> SimdU8Value {
-                let is_third_byte = prev2.gt(SimdU8Value::splat(0b1110_0000 - 1));
-                let is_fourth_byte = prev3.gt(SimdU8Value::splat(0b1111_0000 - 1));
-
-                is_third_byte.or(is_fourth_byte)
-            }
-
-            #[cfg_attr(not(target_arch="aarch64"), target_feature(enable = $feat))]
-            #[inline]
             unsafe fn has_error(&self) -> bool {
                 self.error.any_bit_set()
             }

--- a/src/implementation/algorithm.rs
+++ b/src/implementation/algorithm.rs
@@ -176,7 +176,6 @@ macro_rules! algorithm_simd {
                 self.error = self
                     .error
                     .or(Self::check_multibyte_lengths(input, self.prev, sc));
-                self.incomplete = Self::is_incomplete(input);
                 self.prev = input
             }
 
@@ -200,11 +199,13 @@ macro_rules! algorithm_simd {
                 if input.vals.len() == 2 {
                     self.check_bytes(input.vals[0]);
                     self.check_bytes(input.vals[1]);
+                    self.incomplete = Self::is_incomplete(input.vals[1]);
                 } else if input.vals.len() == 4 {
                     self.check_bytes(input.vals[0]);
                     self.check_bytes(input.vals[1]);
                     self.check_bytes(input.vals[2]);
                     self.check_bytes(input.vals[3]);
+                    self.incomplete = Self::is_incomplete(input.vals[3]);
                 } else {
                     panic!("Unsupported number of chunks");
                 }

--- a/src/implementation/algorithm.rs
+++ b/src/implementation/algorithm.rs
@@ -239,7 +239,7 @@ macro_rules! algorithm_simd {
                             only_ascii = false;
                         }
                     }
-                }    
+                }
             }
 
             let rem = len - idx;

--- a/src/implementation/algorithm.rs
+++ b/src/implementation/algorithm.rs
@@ -156,10 +156,10 @@ macro_rules! algorithm_simd {
                 prev2: SimdU8Value,
                 prev3: SimdU8Value,
             ) -> SimdU8Value {
-                let is_third_byte = prev2.saturating_sub(SimdU8Value::splat(0b1110_0000 - 1));
-                let is_fourth_byte = prev3.saturating_sub(SimdU8Value::splat(0b1111_0000 - 1));
+                let is_third_byte = prev2.gt(SimdU8Value::splat(0b1110_0000 - 1));
+                let is_fourth_byte = prev3.gt(SimdU8Value::splat(0b1111_0000 - 1));
 
-                is_third_byte.or(is_fourth_byte).gt(SimdU8Value::splat0())
+                is_third_byte.or(is_fourth_byte)
             }
 
             #[cfg_attr(not(target_arch="aarch64"), target_feature(enable = $feat))]

--- a/src/implementation/x86/avx2.rs
+++ b/src/implementation/x86/avx2.rs
@@ -255,6 +255,7 @@ impl Utf8CheckAlgorithm<SimdU8Value> {
     }
 }
 
+const ALIGN_READS: bool = true;
 use crate::implementation::helpers::Temp2xSimdChunkA32 as Temp2xSimdChunk;
 simd_input_256_bit!("avx2");
 algorithm_simd!("avx2");

--- a/src/implementation/x86/avx2.rs
+++ b/src/implementation/x86/avx2.rs
@@ -218,7 +218,7 @@ impl SimdU8Value {
 
     #[target_feature(enable = "avx2")]
     #[inline]
-    unsafe fn gt(self, other: Self) -> Self {
+    unsafe fn signed_gt(self, other: Self) -> Self {
         Self::from(_mm256_cmpgt_epi8(self.0, other.0))
     }
 
@@ -239,6 +239,19 @@ impl From<__m256i> for SimdU8Value {
     #[inline]
     fn from(val: __m256i) -> Self {
         Self { 0: val }
+    }
+}
+
+impl Utf8CheckAlgorithm<SimdU8Value> {
+    #[target_feature(enable = "avx2")]
+    #[inline]
+    unsafe fn must_be_2_3_continuation(prev2: SimdU8Value, prev3: SimdU8Value) -> SimdU8Value {
+        let is_third_byte = prev2.saturating_sub(SimdU8Value::splat(0b1110_0000 - 1));
+        let is_fourth_byte = prev3.saturating_sub(SimdU8Value::splat(0b1111_0000 - 1));
+
+        is_third_byte
+            .or(is_fourth_byte)
+            .signed_gt(SimdU8Value::splat0())
     }
 }
 

--- a/src/implementation/x86/sse42.rs
+++ b/src/implementation/x86/sse42.rs
@@ -203,7 +203,7 @@ impl SimdU8Value {
 
     #[target_feature(enable = "sse4.2")]
     #[inline]
-    unsafe fn gt(self, other: Self) -> Self {
+    unsafe fn signed_gt(self, other: Self) -> Self {
         Self::from(_mm_cmpgt_epi8(self.0, other.0))
     }
 
@@ -224,6 +224,19 @@ impl From<__m128i> for SimdU8Value {
     #[inline]
     fn from(val: __m128i) -> Self {
         Self { 0: val }
+    }
+}
+
+impl Utf8CheckAlgorithm<SimdU8Value> {
+    #[target_feature(enable = "sse4.2")]
+    #[inline]
+    unsafe fn must_be_2_3_continuation(prev2: SimdU8Value, prev3: SimdU8Value) -> SimdU8Value {
+        let is_third_byte = prev2.saturating_sub(SimdU8Value::splat(0b1110_0000 - 1));
+        let is_fourth_byte = prev3.saturating_sub(SimdU8Value::splat(0b1111_0000 - 1));
+
+        is_third_byte
+            .or(is_fourth_byte)
+            .signed_gt(SimdU8Value::splat0())
     }
 }
 

--- a/src/implementation/x86/sse42.rs
+++ b/src/implementation/x86/sse42.rs
@@ -240,6 +240,7 @@ impl Utf8CheckAlgorithm<SimdU8Value> {
     }
 }
 
+const ALIGN_READS: bool = true;
 use crate::implementation::helpers::Temp2xSimdChunkA16 as Temp2xSimdChunk;
 simd_input_128_bit!("sse4.2");
 algorithm_simd!("sse4.2");


### PR DESCRIPTION
- One optimization pulled from simdjson: Neon provides unsigned byte comparison which can be employed to save an instruction.
- Alignment configurable per arch. Aligning access performs worse on Apple Silicon and only provides benefits for large ASCII strings on Raspberry Pi 4 while performing worse on other strings. Thus disabled for aarch64.
- `is_incomplete()` only needs to be called for the last vector. No assembly difference since the compiler already figured that out via SSA.