### PR TITLE
Only require SSE 4.1 as no SSE 4.2 instructions are used.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolchain: ["1.38.0", stable, beta, nightly ]
         features: ["", "--features std", "--features public_imp", "--features std,public_imp"]
-        rustflags: ["", "-C target-feature=+avx2", "-C target-feature=+sse4.2"]
+        rustflags: ["", "-C target-feature=+avx2", "-C target-feature=+sse4.1"]
         exclude:
             - os: macos-latest
               rustflags: "-C target-feature=+avx2"
@@ -69,7 +69,7 @@ jobs:
           cargo clean;RUSTFLAGS="-C target-feature=+avx2" cargo asm|grep -v drop_in_place|diff -u expected-methods-x86-std-avx2.txt -
           cargo clean;cargo asm --no-default-features|grep -v drop_in_place|diff -u expected-methods-x86-nostd-fallback.txt -
           cargo clean;RUSTFLAGS="-C target-feature=+avx2" cargo asm --no-default-features|grep -v drop_in_place|diff -u expected-methods-x86-nostd-avx2.txt -
-          cargo clean;RUSTFLAGS="-C target-feature=+sse4.2" cargo asm --no-default-features|grep -v drop_in_place|diff -u expected-methods-x86-nostd-sse42.txt -
+          cargo clean;RUSTFLAGS="-C target-feature=+sse4.1" cargo asm --no-default-features|grep -v drop_in_place|diff -u expected-methods-x86-nostd-sse41.txt -
 
   test-inlining-aarch64:
     runs-on: ubuntu-latest
@@ -148,7 +148,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         toolchain: [stable, nightly]
         features: ["", "--features std", "--features public_imp", "--features std,public_imp"]
-        rustflags: ["", "-C target-feature=+avx2", "-C target-feature=+sse4.2"]
+        rustflags: ["", "-C target-feature=+avx2", "-C target-feature=+sse4.1"]
         target: [i686-unknown-linux-gnu, i686-pc-windows-msvc]
         exclude:
           - os: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simdutf8"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Hans Kratz <hans@appfour.com>"]
 edition = "2018"
 description = "SIMD-accelerated UTF-8 validation."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,16 @@ readme = "README.md"
 keywords = ["utf-8", "unicode", "string", "validation", "simd"]
 categories = ["encoding", "algorithms", "no-std"]
 license = "MIT OR Apache-2.0"
-exclude = ["/.github", "/.vscode", "/bench", "/fuzzing", "/img", "expected-methods-*.txt"]
+exclude = [
+    "/.gitignore",
+    "/.github",
+    "/.vscode",
+    "/bench",
+    "/fuzzing",
+    "/img",
+    "/inlining",
+    "TODO.md",
+]
 
 [features]
 default = ["std"]

--- a/fuzzing/common/src/lib.rs
+++ b/fuzzing/common/src/lib.rs
@@ -32,8 +32,8 @@ pub fn test_utf8(data: &[u8]) {
         let compat_simd_res = simdutf8::compat::imp::x86::avx2::validate_utf8(data);
         check_basic_simd_res(std_res, basic_simd_res);
         check_compat_simd_res(std_res, compat_simd_res);
-        let basic_simd_res = simdutf8::basic::imp::x86::sse42::validate_utf8(data);
-        let compat_simd_res = simdutf8::compat::imp::x86::sse42::validate_utf8(data);
+        let basic_simd_res = simdutf8::basic::imp::x86::sse41::validate_utf8(data);
+        let compat_simd_res = simdutf8::compat::imp::x86::sse41::validate_utf8(data);
         check_basic_simd_res(std_res, basic_simd_res);
         check_compat_simd_res(std_res, compat_simd_res);
     }

--- a/inlining/expected-methods-x86-nostd-sse41.txt
+++ b/inlining/expected-methods-x86-nostd-sse41.txt
@@ -6,6 +6,6 @@
 <simdutf8::compat::Utf8Error as core::fmt::Display>::fmt
 simdutf8::implementation::helpers::get_compat_error
 simdutf8::implementation::x86::validate_utf8_basic
-simdutf8::implementation::x86::validate_utf8_basic_sse42
+simdutf8::implementation::x86::validate_utf8_basic_sse41
 simdutf8::implementation::x86::validate_utf8_compat
-simdutf8::implementation::x86::validate_utf8_compat_sse42
+simdutf8::implementation::x86::validate_utf8_compat_sse41

--- a/inlining/expected-methods-x86-std.txt
+++ b/inlining/expected-methods-x86-std.txt
@@ -9,8 +9,8 @@ simdutf8::implementation::validate_utf8_basic_fallback
 simdutf8::implementation::validate_utf8_compat_fallback
 simdutf8::implementation::x86::avx2::validate_utf8_basic
 simdutf8::implementation::x86::avx2::validate_utf8_compat
-simdutf8::implementation::x86::sse42::validate_utf8_basic
-simdutf8::implementation::x86::sse42::validate_utf8_compat
+simdutf8::implementation::x86::sse41::validate_utf8_basic
+simdutf8::implementation::x86::sse41::validate_utf8_compat
 simdutf8::implementation::x86::validate_utf8_basic::FN
 simdutf8::implementation::x86::validate_utf8_basic::get_fastest
 simdutf8::implementation::x86::validate_utf8_compat::FN

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -210,11 +210,8 @@ pub mod imp {
             pub use crate::implementation::x86::sse41::ChunkedUtf8ValidatorImp;
             pub use crate::implementation::x86::sse41::Utf8ValidatorImp;
         }
-        /// Includes the validation implementation for SSE 4.2-compatible CPUs.
-        ///
-        /// This deprecated and provided for backward compatibilit only. It actually redirects to
-        /// the sse41 module. All CPUs supporting SSE 4.2 also support  SSE 4.1 and there is no
-        /// special implementation of the UTF-8 validation for SSE 4.2.
+        /// This module is deprecated and everything  in it redirects to the SSE 4.1 module. It is provided
+        /// for backward compatibility only. There is no SEE 4.2-specific implementation.
         #[deprecated(since = "0.1.4", note = "Please use the sse41 module instead")]
         pub mod sse42 {
             pub use crate::implementation::x86::sse41::validate_utf8_basic as validate_utf8;

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -201,14 +201,25 @@ pub mod imp {
             pub use crate::implementation::x86::avx2::ChunkedUtf8ValidatorImp;
             pub use crate::implementation::x86::avx2::Utf8ValidatorImp;
         }
+        /// Includes the validation implementation for SSE 4.1-compatible CPUs.
+        ///
+        /// Using the provided functionality on CPUs which do not support SSE 4.1 is undefined
+        /// behavior and will very likely cause a crash.
+        pub mod sse41 {
+            pub use crate::implementation::x86::sse41::validate_utf8_basic as validate_utf8;
+            pub use crate::implementation::x86::sse41::ChunkedUtf8ValidatorImp;
+            pub use crate::implementation::x86::sse41::Utf8ValidatorImp;
+        }
         /// Includes the validation implementation for SSE 4.2-compatible CPUs.
         ///
-        /// Using the provided functionality on CPUs which do not support SSE 4.2 is undefined
-        /// behavior and will very likely cause a crash.
+        /// This deprecated and provided for backward compatibilit only. It actually redirects to
+        /// the sse41 module. All CPUs supporting SSE 4.2 also support  SSE 4.1 and there is no
+        /// special implementation of the UTF-8 validation for SSE 4.2.
+        #[deprecated(since = "0.1.4", note = "Please use the sse41 module instead")]
         pub mod sse42 {
-            pub use crate::implementation::x86::sse42::validate_utf8_basic as validate_utf8;
-            pub use crate::implementation::x86::sse42::ChunkedUtf8ValidatorImp;
-            pub use crate::implementation::x86::sse42::Utf8ValidatorImp;
+            pub use crate::implementation::x86::sse41::validate_utf8_basic as validate_utf8;
+            pub use crate::implementation::x86::sse41::ChunkedUtf8ValidatorImp;
+            pub use crate::implementation::x86::sse41::Utf8ValidatorImp;
         }
     }
 

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -110,9 +110,18 @@ pub mod imp {
         pub mod avx2 {
             pub use crate::implementation::x86::avx2::validate_utf8_compat as validate_utf8;
         }
+        /// Includes the validation implementation for SSE 4.1-compatible CPUs.
+        pub mod sse41 {
+            pub use crate::implementation::x86::sse41::validate_utf8_compat as validate_utf8;
+        }
         /// Includes the validation implementation for SSE 4.2-compatible CPUs.
+        ///
+        /// This deprecated and provided for backward compatibilit only. It actually redirects to
+        /// the sse41 module. All CPUs supporting SSE 4.2 also support  SSE 4.1 and there is no
+        /// special implementation of the UTF-8 validation for SSE 4.2.
+        #[deprecated(since = "0.1.4", note = "Please use the sse41 module instead")]
         pub mod sse42 {
-            pub use crate::implementation::x86::sse42::validate_utf8_compat as validate_utf8;
+            pub use crate::implementation::x86::sse41::validate_utf8_compat as validate_utf8;
         }
     }
 

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -114,11 +114,8 @@ pub mod imp {
         pub mod sse41 {
             pub use crate::implementation::x86::sse41::validate_utf8_compat as validate_utf8;
         }
-        /// Includes the validation implementation for SSE 4.2-compatible CPUs.
-        ///
-        /// This deprecated and provided for backward compatibilit only. It actually redirects to
-        /// the sse41 module. All CPUs supporting SSE 4.2 also support  SSE 4.1 and there is no
-        /// special implementation of the UTF-8 validation for SSE 4.2.
+        /// This module is deprecated and everything  in it redirects to the SSE 4.1 module. It is provided
+        /// for backward compatibility only. There is no SEE 4.2-specific implementation.
         #[deprecated(since = "0.1.4", note = "Please use the sse41 module instead")]
         pub mod sse42 {
             pub use crate::implementation::x86::sse41::validate_utf8_compat as validate_utf8;

--- a/src/implementation/helpers.rs
+++ b/src/implementation/helpers.rs
@@ -44,7 +44,7 @@ pub(crate) unsafe fn memcpy_unaligned_nonoverlapping_inline_opt_lt_64(
     mut dest: *mut u8,
     mut len: usize,
 ) {
-    // This gets properly auto-vectorized on AVX 2 and SSE 4.2
+    // This gets properly auto-vectorized on AVX 2 and SSE 4.1
     #[inline]
     unsafe fn memcpy_u64(src: &mut *const u8, dest: &mut *mut u8) {
         #[allow(clippy::cast_ptr_alignment)]

--- a/src/implementation/x86/mod.rs
+++ b/src/implementation/x86/mod.rs
@@ -2,7 +2,7 @@
 pub(crate) mod avx2;
 
 #[allow(dead_code)]
-pub(crate) mod sse42;
+pub(crate) mod sse41;
 
 #[allow(unused_imports)]
 use super::helpers::SIMD_CHUNK_SIZE;
@@ -40,8 +40,8 @@ pub(crate) unsafe fn validate_utf8_basic(
 fn get_fastest_available_implementation_basic() -> super::ValidateUtf8Fn {
     if std::is_x86_feature_detected!("avx2") {
         avx2::validate_utf8_basic
-    } else if std::is_x86_feature_detected!("sse4.2") {
-        sse42::validate_utf8_basic
+    } else if std::is_x86_feature_detected!("sse4.1") {
+        sse41::validate_utf8_basic
     } else {
         super::validate_utf8_basic_fallback
     }
@@ -71,7 +71,7 @@ unsafe fn validate_utf8_basic_avx2(
 #[cfg(all(
     not(feature = "std"),
     not(target_feature = "avx2"),
-    target_feature = "sse4.2"
+    target_feature = "sse4.1"
 ))]
 pub(crate) unsafe fn validate_utf8_basic(
     input: &[u8],
@@ -80,25 +80,25 @@ pub(crate) unsafe fn validate_utf8_basic(
         return super::validate_utf8_basic_fallback(input);
     }
 
-    validate_utf8_basic_sse42(input)
+    validate_utf8_basic_sse41(input)
 }
 
 #[cfg(all(
     not(feature = "std"),
     not(target_feature = "avx2"),
-    target_feature = "sse4.2"
+    target_feature = "sse4.1"
 ))]
 #[inline(never)]
-unsafe fn validate_utf8_basic_sse42(
+unsafe fn validate_utf8_basic_sse41(
     input: &[u8],
 ) -> core::result::Result<(), crate::basic::Utf8Error> {
-    sse42::validate_utf8_basic(input)
+    sse41::validate_utf8_basic(input)
 }
 
 #[cfg(all(
     not(feature = "std"),
     not(target_feature = "avx2"),
-    not(target_feature = "sse4.2")
+    not(target_feature = "sse4.1")
 ))]
 pub(crate) use super::validate_utf8_basic_fallback as validate_utf8_basic;
 
@@ -136,8 +136,8 @@ pub(crate) unsafe fn validate_utf8_compat(
 fn get_fastest_available_implementation_compat() -> super::ValidateUtf8CompatFn {
     if std::is_x86_feature_detected!("avx2") {
         avx2::validate_utf8_compat
-    } else if std::is_x86_feature_detected!("sse4.2") {
-        sse42::validate_utf8_compat
+    } else if std::is_x86_feature_detected!("sse4.1") {
+        sse41::validate_utf8_compat
     } else {
         super::validate_utf8_compat_fallback
     }
@@ -167,7 +167,7 @@ unsafe fn validate_utf8_compat_avx2(
 #[cfg(all(
     not(feature = "std"),
     not(target_feature = "avx2"),
-    target_feature = "sse4.2"
+    target_feature = "sse4.1"
 ))]
 pub(crate) unsafe fn validate_utf8_compat(
     input: &[u8],
@@ -176,24 +176,24 @@ pub(crate) unsafe fn validate_utf8_compat(
         return super::validate_utf8_compat_fallback(input);
     }
 
-    validate_utf8_compat_sse42(input)
+    validate_utf8_compat_sse41(input)
 }
 
 #[cfg(all(
     not(feature = "std"),
     not(target_feature = "avx2"),
-    target_feature = "sse4.2"
+    target_feature = "sse4.1"
 ))]
 #[inline(never)]
-pub(crate) unsafe fn validate_utf8_compat_sse42(
+pub(crate) unsafe fn validate_utf8_compat_sse41(
     input: &[u8],
 ) -> core::result::Result<(), crate::compat::Utf8Error> {
-    sse42::validate_utf8_compat(input)
+    sse41::validate_utf8_compat(input)
 }
 
 #[cfg(all(
     not(feature = "std"),
     not(target_feature = "avx2"),
-    not(target_feature = "sse4.2")
+    not(target_feature = "sse4.1")
 ))]
 pub(crate) use super::validate_utf8_compat_fallback as validate_utf8_compat;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,8 +78,8 @@
 //! compile-time and runtime selection is disabled.
 //!
 //! For no-std support (compiled with `--no-default-features`) the implementation is always selected at compile time based on
-//! the targeted CPU. Use `RUSTFLAGS="-C target-feature=+avx2"` for the AVX 2 implementation or `RUSTFLAGS="-C target-feature=+sse4.2"`
-//! for the SSE 4.2 implementation.
+//! the targeted CPU. Use `RUSTFLAGS="-C target-feature=+avx2"` for the AVX 2 implementation or `RUSTFLAGS="-C target-feature=+sse4.1"`
+//! for the SSE 4.1 implementation.
 //!
 //! ### ARM64
 //! For ARM64 support Nightly Rust is needed and the crate feature `aarch64_neon` needs to be enabled. CAVE: If this features is

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -114,13 +114,13 @@ fn test_valid_public_imp(input: &[u8]) {
             );
         }
 
-        #[cfg(target_feature = "sse4.2")]
+        #[cfg(target_feature = "sse4.1")]
         unsafe {
-            assert!(simdutf8::basic::imp::x86::sse42::validate_utf8(input).is_ok());
-            assert!(simdutf8::compat::imp::x86::sse42::validate_utf8(input).is_ok());
+            assert!(simdutf8::basic::imp::x86::sse41::validate_utf8(input).is_ok());
+            assert!(simdutf8::compat::imp::x86::sse41::validate_utf8(input).is_ok());
 
-            test_streaming::<simdutf8::basic::imp::x86::sse42::Utf8ValidatorImp>(input, true);
-            test_chunked_streaming::<simdutf8::basic::imp::x86::sse42::ChunkedUtf8ValidatorImp>(
+            test_streaming::<simdutf8::basic::imp::x86::sse41::Utf8ValidatorImp>(input, true);
+            test_chunked_streaming::<simdutf8::basic::imp::x86::sse41::ChunkedUtf8ValidatorImp>(
                 input, true,
             );
         }
@@ -173,15 +173,15 @@ fn test_invalid_public_imp(input: &[u8], valid_up_to: usize, error_len: Option<u
                 input, false,
             );
         }
-        #[cfg(target_feature = "sse4.2")]
+        #[cfg(target_feature = "sse4.1")]
         unsafe {
-            assert!(simdutf8::basic::imp::x86::sse42::validate_utf8(input).is_err());
-            let err = simdutf8::compat::imp::x86::sse42::validate_utf8(input).unwrap_err();
+            assert!(simdutf8::basic::imp::x86::sse41::validate_utf8(input).is_err());
+            let err = simdutf8::compat::imp::x86::sse41::validate_utf8(input).unwrap_err();
             assert_eq!(err.valid_up_to(), valid_up_to);
             assert_eq!(err.error_len(), error_len);
 
-            test_streaming::<simdutf8::basic::imp::x86::sse42::Utf8ValidatorImp>(input, false);
-            test_chunked_streaming::<simdutf8::basic::imp::x86::sse42::ChunkedUtf8ValidatorImp>(
+            test_streaming::<simdutf8::basic::imp::x86::sse41::Utf8ValidatorImp>(input, false);
+            test_chunked_streaming::<simdutf8::basic::imp::x86::sse41::ChunkedUtf8ValidatorImp>(
                 input, false,
             );
         }
@@ -424,17 +424,17 @@ fn test_avx2_chunked_panic() {
 
 #[test]
 #[should_panic]
-#[cfg(all(feature = "public_imp", target_feature = "sse4.2"))]
-fn test_sse42_chunked_panic() {
+#[cfg(all(feature = "public_imp", target_feature = "sse4.1"))]
+fn test_sse41_chunked_panic() {
     test_chunked_streaming_with_chunk_size::<
-        simdutf8::basic::imp::x86::sse42::ChunkedUtf8ValidatorImp,
+        simdutf8::basic::imp::x86::sse41::ChunkedUtf8ValidatorImp,
     >(b"abcd", 1, true);
 }
 
 #[test]
 #[should_panic]
 #[cfg(all(feature = "public_imp", target_arch = "aarch64"))]
-fn test_sse42_chunked_panic() {
+fn test_sse41_chunked_panic() {
     test_chunked_streaming_with_chunk_size::<
         simdutf8::basic::imp::aarch64::neon::ChunkedUtf8ValidatorImp,
     >(b"abcd", 1, true);


### PR DESCRIPTION
Also deprecates the sse42 low-level API.