### PR TITLE
Use released version of rustup again as the OOM issue has been fixed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTUP_UPDATE_ROOT: https://dev-static.rust-lang.org/rustup
 
 jobs:
   test:
@@ -26,9 +25,6 @@ jobs:
               rustflags: "-C target-feature=+avx2"
     steps:
       - uses: actions/checkout@v2
-      - name: Update rustup
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: rustup self update
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: ${{ matrix.toolchain }}
@@ -81,8 +77,6 @@ jobs:
         working-directory: inlining
     steps:
       - uses: actions/checkout@v2
-      - name: Update rustup
-        run: rustup self update
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: nightly
@@ -102,8 +96,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Update rustup
-        run: rustup self update
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: nightly
@@ -130,8 +122,6 @@ jobs:
             target: aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v2
-      - name: Update rustup
-        run: rustup self update
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: ${{ matrix.toolchain }}
@@ -157,9 +147,6 @@ jobs:
             target: i686-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v2
-      - name: Update rustup
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: rustup self update
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: ${{ matrix.toolchain }}
@@ -175,8 +162,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Update rustup
-        run: rustup self update
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: stable
@@ -190,8 +175,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Update rustup
-        run: rustup self update
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: nightly


### PR DESCRIPTION
Revert "Use rustup beta, which fixes Windows OOM issues"

This reverts commit 6f5c6880aa9e32947ff71ab52df1fa638469da0a.

Revert "Try with rustup beta"

This reverts commit 8b206bdb54f47b62dfd7d643aadd3217039e1407.

Revert "Decrease rustup RAM usage."

This reverts commit 31b71043ff31ea323b0102d0007d324210383542.