### PR TITLE
Makes the panic test conditional on aarch64_neon

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -48,7 +48,7 @@ fn test_valid(input: &[u8]) {
     test_valid_public_imp(input);
 }
 
-// unused for cases where public_imp is set but no SSE functions generated...
+// unused for cases where public_imp is set but no SIMD functions generated...
 #[cfg(feature = "public_imp")]
 #[allow(dead_code)]
 fn test_streaming<T: simdutf8::basic::imp::Utf8Validator>(input: &[u8], ok: bool) {
@@ -62,7 +62,7 @@ fn test_streaming<T: simdutf8::basic::imp::Utf8Validator>(input: &[u8], ok: bool
     }
 }
 
-// unused for cases where public_imp is set but no SSE functions generated...
+// unused for cases where public_imp is set but no SIMD functions generated...
 #[cfg(feature = "public_imp")]
 #[allow(dead_code)]
 fn test_streaming_blocks<T: simdutf8::basic::imp::Utf8Validator>(
@@ -79,7 +79,7 @@ fn test_streaming_blocks<T: simdutf8::basic::imp::Utf8Validator>(
     }
 }
 
-// unused for cases where public_imp is set but no SSE functions generated...
+// unused for cases where public_imp is set but no SIMD functions generated...
 #[cfg(feature = "public_imp")]
 #[allow(dead_code)]
 fn test_chunked_streaming<T: simdutf8::basic::imp::ChunkedUtf8Validator>(input: &[u8], ok: bool) {
@@ -88,7 +88,7 @@ fn test_chunked_streaming<T: simdutf8::basic::imp::ChunkedUtf8Validator>(input: 
     }
 }
 
-// unused for cases where public_imp is set but no SSE functions generated...
+// unused for cases where public_imp is set but no SIMD functions generated...
 #[cfg(feature = "public_imp")]
 #[allow(dead_code)]
 fn test_chunked_streaming_with_chunk_size<T: simdutf8::basic::imp::ChunkedUtf8Validator>(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -48,7 +48,9 @@ fn test_valid(input: &[u8]) {
     test_valid_public_imp(input);
 }
 
+// unused for cases where public_imp is set but no SSE functions generated...
 #[cfg(feature = "public_imp")]
+#[allow(dead_code)]
 fn test_streaming<T: simdutf8::basic::imp::Utf8Validator>(input: &[u8], ok: bool) {
     unsafe {
         let mut validator = T::new();
@@ -60,7 +62,9 @@ fn test_streaming<T: simdutf8::basic::imp::Utf8Validator>(input: &[u8], ok: bool
     }
 }
 
+// unused for cases where public_imp is set but no SSE functions generated...
 #[cfg(feature = "public_imp")]
+#[allow(dead_code)]
 fn test_streaming_blocks<T: simdutf8::basic::imp::Utf8Validator>(
     input: &[u8],
     block_size: usize,
@@ -75,14 +79,18 @@ fn test_streaming_blocks<T: simdutf8::basic::imp::Utf8Validator>(
     }
 }
 
+// unused for cases where public_imp is set but no SSE functions generated...
 #[cfg(feature = "public_imp")]
+#[allow(dead_code)]
 fn test_chunked_streaming<T: simdutf8::basic::imp::ChunkedUtf8Validator>(input: &[u8], ok: bool) {
     for i in [64, 128, 256, 1024, 65536].iter() {
         test_chunked_streaming_with_chunk_size::<T>(input, *i, ok)
     }
 }
 
+// unused for cases where public_imp is set but no SSE functions generated...
 #[cfg(feature = "public_imp")]
+#[allow(dead_code)]
 fn test_chunked_streaming_with_chunk_size<T: simdutf8::basic::imp::ChunkedUtf8Validator>(
     input: &[u8],
     chunk_size: usize,
@@ -433,8 +441,12 @@ fn test_sse42_chunked_panic() {
 
 #[test]
 #[should_panic]
-#[cfg(all(feature = "public_imp", target_arch = "aarch64"))]
-fn test_sse42_chunked_panic() {
+#[cfg(all(
+    feature = "public_imp",
+    target_arch = "aarch64",
+    feature = "aarch64_neon"
+))]
+fn test_neon_chunked_panic() {
     test_chunked_streaming_with_chunk_size::<
         simdutf8::basic::imp::aarch64::neon::ChunkedUtf8ValidatorImp,
     >(b"abcd", 1, true);


### PR DESCRIPTION
When doing the CI integration for #56, I noticed some test warnings that I wasn't sure if they were a result of the WASM code paths or behavior of the existing tests, I decided to use my m1 Mac Mini to see if I could replicate it outside of WASM because the AArch64 target is kind of similar to how the WASM target builds (no autodetection, etc.).

I found the following:
```sh
❯ cargo +nightly test --no-default-features --features public_imp --all-targets
   Compiling simdutf8 v0.1.3 (/Users/almann/CLionProjects/simdutf8)
error[E0433]: failed to resolve: could not find `aarch64` in `imp`
   --> tests/tests.rs:439:31
    |
439 |         simdutf8::basic::imp::aarch64::neon::ChunkedUtf8ValidatorImp,
    |                               ^^^^^^^ could not find `aarch64` in `imp`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `simdutf8` due to previous error
❯ cargo +nightly build --no-default-features --features public_imp --all-targets
   Compiling simdutf8 v0.1.3 (/Users/almann/CLionProjects/simdutf8)
error[E0433]: failed to resolve: could not find `aarch64` in `imp`
   --> tests/tests.rs:439:31
    |
439 |         simdutf8::basic::imp::aarch64::neon::ChunkedUtf8ValidatorImp,
    |                               ^^^^^^^ could not find `aarch64` in `imp`
```

This commit fixes the AArch64 tests when building with `public_imp` but no `aarch64_neon`.

With this patch:
```sh
❯ cargo +nightly build --no-default-features --features public_imp --all-targets
   Compiling simdutf8 v0.1.3 (/Users/almann/CLionProjects/simdutf8)
    Finished dev [unoptimized + debuginfo] target(s) in 0.64s
❯ cargo +nightly test --no-default-features --features public_imp --all-targets
    Finished test [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests (target/debug/deps/simdutf8-d69a483c09ed8fb7)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/tests.rs (target/debug/deps/tests-2c7cc8963b9ca6a2)

running 11 tests
test error_debug_basic ... ok
test error_debug_compat ... ok
test error_derives_basic ... ok
test error_derives_compat ... ok
test error_display_basic ... ok
test error_display_compat ... ok
test incomplete_on_32nd_byte ... ok
test incomplete_on_64th_byte ... ok
test incomplete_on_64th_byte_65_bytes_total ... ok
test simple_valid ... ok
test simple_invalid ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

     Running unittests (target/debug/examples/streaming-37d9c7ff0567f9af)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Also disables dead code warning on test functions. Specifically disables the warning in the case that the `public_imp` flag is set, but there are no SSE generated methods (e.g., no `aarch64_neon`).

Also fixes `test_neon_chunked_panic` named as `sse42`.

This does not add `--all-targets` to the CI cross builds as this requires at least the appropriate linker to be installed.