### PR TITLE
Fixes mangled markdown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ For ARM64 support Nightly Rust is needed and the crate feature `aarch64_neon` ne
 not turned on the non-SIMD std library implementation is used.
 
 ### WASM32
-For wasm32 support, the implementation is selected at compile time based on the presence of the `simd128` target feature.```
-target.  Use `RUSTFLAGS="-C target-feature=+simd128"` to enable the WASM SIMD implementation.  WASM, at
+For wasm32 support, the implementation is selected at compile time based on the presence of the `simd128` target feature.
+Use `RUSTFLAGS="-C target-feature=+simd128"` to enable the WASM SIMD implementation.  WASM, at
 the time of this writing, doesn't have a way to detect SIMD through WASM itself.  Although this capability
 is available in various WASM host environments (e.g., [wasm-feature-detect] in the web browser), there is no portable
 way from within the library to detect this.


### PR DESCRIPTION
In #56, some code review suggestions got a bit mangled, this was fixed in `lib.rs`, but not in the corresponding README.