### PR TITLE
Fix unconditional panic warnings

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         toolchain: [stable, beta, nightly]
         features: ["", "--features std", "--features public_imp", "--features std,public_imp"]
         rustflags: ["", "-C target-feature=+simd128"]

--- a/src/implementation/algorithm.rs
+++ b/src/implementation/algorithm.rs
@@ -181,21 +181,19 @@ macro_rules! algorithm_simd {
 
             #[cfg_attr(not(target_arch="aarch64"), target_feature(enable = $feat))]
             #[inline]
-            #[allow(unconditional_panic)] // does not panic because len is checked
-            #[allow(const_err)] // the same, but for Rust 1.38.0
             unsafe fn check_block(&mut self, input: SimdInput) {
                 // WORKAROUND
                 // necessary because the for loop is not unrolled on ARM64
                 if input.vals.len() == 2 {
-                    self.check_bytes(input.vals[0]);
-                    self.check_bytes(input.vals[1]);
-                    self.incomplete = Self::is_incomplete(input.vals[1]);
+                    self.check_bytes(*input.vals.get_unchecked(0));
+                    self.check_bytes(*input.vals.get_unchecked(1));
+                    self.incomplete = Self::is_incomplete(*input.vals.get_unchecked(1));
                 } else if input.vals.len() == 4 {
-                    self.check_bytes(input.vals[0]);
-                    self.check_bytes(input.vals[1]);
-                    self.check_bytes(input.vals[2]);
-                    self.check_bytes(input.vals[3]);
-                    self.incomplete = Self::is_incomplete(input.vals[3]);
+                    self.check_bytes(*input.vals.get_unchecked(0));
+                    self.check_bytes(*input.vals.get_unchecked(1));
+                    self.check_bytes(*input.vals.get_unchecked(2));
+                    self.check_bytes(*input.vals.get_unchecked(3));
+                    self.incomplete = Self::is_incomplete(*input.vals.get_unchecked(3));
                 } else {
                     panic!("Unsupported number of chunks");
                 }


### PR DESCRIPTION
We can just use `.get_unsafe()` here. Drive-by-fix: clippy warning. Drive-by-fix: clippy warning.

Fixes #68.