### PR TITLE
Fix Undefined Behavior in WebAssembly SIMD128

### DIFF
--- a/src/implementation/wasm32/simd128.rs
+++ b/src/implementation/wasm32/simd128.rs
@@ -88,9 +88,8 @@ impl SimdU8Value {
     }
 
     #[inline]
-    #[allow(clippy::cast_ptr_alignment)]
     unsafe fn load_from(ptr: *const u8) -> Self {
-        Self::from(*(ptr.cast::<v128>()))
+        Self::from(ptr.cast::<v128>().read_unaligned())
     }
 
     #[inline]


### PR DESCRIPTION
The pointer is actually unaligned, so this needs to be an unaligned read as otherwise UB gets invoked. A debug build nowadays panics here to detect the UB.