### PR TITLE
Fix wasm ci

### DIFF
--- a/src/implementation/helpers.rs
+++ b/src/implementation/helpers.rs
@@ -111,6 +111,7 @@ impl TempSimdChunkA32 {
 }
 
 #[derive(Clone, Copy)]
+#[allow(dead_code)]
 pub(crate) struct SimdU8Value<T>(pub(crate) T)
 where
     T: Copy;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -5,10 +5,10 @@ use simdutf8::basic::from_utf8_mut as basic_from_utf8_mut;
 use simdutf8::compat::from_utf8 as compat_from_utf8;
 use simdutf8::compat::from_utf8_mut as compat_from_utf8_mut;
 
-#[cfg(not(features = "std"))]
+#[cfg(not(feature = "std"))]
 extern crate std;
 
-#[cfg(not(features = "std"))]
+#[cfg(not(feature = "std"))]
 use std::{borrow::ToOwned, format};
 
 pub trait BStrExt {


### PR DESCRIPTION
`SimdU8Value` can be unused if no SIMD implementation is available.