### PR TITLE
v0.1.5 prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 ### Performance
 * WASM: Don't use u8x16_bitmask for ASCII Check (#79) (thanks @CryZe)
 
-
 ## [0.1.4] - 2022-04-02
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 ## [Unreleased]
 
+### Bug fixes
+* Fix Undefined Behavior in WebAssembly SIMD128 (#86) (thanks @CryZe)
+* Documentation and clippy fixes (thanks @rtfeldman, @jqnatividad, @rhysd)
+
+### Performance
+* WASM: Don't use u8x16_bitmask for ASCII Check (#79) (thanks @CryZe)
+
+
 ## [0.1.4] - 2022-04-02
 
 ### New features
@@ -72,4 +80,3 @@
 [0.0.3]: https://github.com/rusticstuff/simdutf8/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/rusticstuff/simdutf8/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/rusticstuff/simdutf8/releases/tag/v0.0.1
-

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ the targeted CPU. Use `RUSTFLAGS="-C target-feature=+avx2"` for the AVX 2 implem
 for the SSE 4.2 implementation.
 
 ### ARM64
-The SIMD implementation is automatically used since Rust 1.61.
+The SIMD implementation is used automatically since Rust 1.61.
 
 ### WASM32
 For wasm32 support, the implementation is selected at compile time based on the presence of the `simd128` target feature.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This library has been thoroughly tested with sample data as well as fuzzing and 
 * `basic` API for the fastest validation, optimized for valid UTF-8
 * `compat` API as a fully compatible replacement for `std::str::from_utf8()`
 * Supports AVX 2 and SSE 4.2 implementations on x86 and x86-64
-* 🆕 ARM64 (aarch64) SIMD is supported with Rust 1.59 and 1.60 (use feature `aarch64_neon`) and Nightly (no extra feature needed)
+* 🆕 ARM64 (aarch64) SIMD is supported since Rust 1.61
 * 🆕 WASM (wasm32) SIMD is supported
 * x86-64: Up to 23 times faster than the std library on valid non-ASCII, up to four times faster on ASCII
 * aarch64: Up to eleven times faster than the std library on valid non-ASCII, up to four times faster on ASCII (Apple Silicon)
@@ -30,11 +30,6 @@ Add the dependency to your Cargo.toml file:
 ```toml
 [dependencies]
 simdutf8 = "0.1.4"
-```
-For ARM64 SIMD support on Rust 1.59 and 1.60:
-```toml
-[dependencies]
-simdutf8 = { version = "0.1.4", features = ["aarch64_neon"] }
 ```
 
 Use `simdutf8::basic::from_utf8()` as a drop-in replacement for `std::str::from_utf8()`.
@@ -85,11 +80,7 @@ the targeted CPU. Use `RUSTFLAGS="-C target-feature=+avx2"` for the AVX 2 implem
 for the SSE 4.2 implementation.
 
 ### ARM64
-The SIMD implementation is only available on Rust Nightly and Rust 1.59 or later. On Rust Nightly it is now turned on
-automatically.
-To get the SIMD implementation with Rust 1.59 and 1.60 the crate feature `aarch64_neon` needs to be enabled.
-For Rust Nightly this will no longer be required (but does not hurt either). It is expected that the SIMD implementation
-will be enabled automatically starting with Rust 1.61.
+The SIMD implementation is automatically used since Rust 1.61.
 
 ### WASM32
 For wasm32 support, the implementation is selected at compile time based on the presence of the `simd128` target feature.
@@ -176,4 +167,3 @@ simdjson itself is distributed under the Apache License 2.0.
 
 ## References
 John Keiser, Daniel Lemire, [Validating UTF-8 In Less Than One Instruction Per Byte](https://arxiv.org/abs/2010.03090), Software: Practice and Experience 51 (5), 2021
-

--- a/release.toml
+++ b/release.toml
@@ -4,3 +4,4 @@ pre-release-replacements = [
   {file="README.md", search="simdutf8 = \"[0-9.]+\"", replace="simdutf8 = \"{{version}}\"", exactly=1},
   {file="src/lib.rs", search="simdutf8 = \"[0-9.]+\"", replace="simdutf8 = \"{{version}}\"", exactly=1},
 ]
+allow-branch = ["main"]

--- a/release.toml
+++ b/release.toml
@@ -2,8 +2,5 @@ pre-release-replacements = [
   {file="CHANGELOG.md", search="## \\[Unreleased\\]", replace="## [Unreleased]\n\n## [{{version}}] - {{date}}", exactly=1},
   {file="CHANGELOG.md", search="\\[Unreleased\\]: https://github\\.com/rusticstuff/simdutf8/compare/v[0-9.]+\\.\\.\\.HEAD", replace="[Unreleased]: https://github.com/rusticstuff/simdutf8/compare/v{{version}}...HEAD\n[{{version}}]: https://github.com/rusticstuff/simdutf8/compare/v{{prev_version}}...v{{version}}", exactly=1},
   {file="README.md", search="simdutf8 = \"[0-9.]+\"", replace="simdutf8 = \"{{version}}\"", exactly=1},
-  {file="README.md", search="simdutf8 = \\{ version = \"[0-9.]+\"", replace="simdutf8 = { version = \"{{version}}\"", exactly=1},
   {file="src/lib.rs", search="simdutf8 = \"[0-9.]+\"", replace="simdutf8 = \"{{version}}\"", exactly=1},
-  {file="src/lib.rs", search="simdutf8 = \\{ version = \"[0-9.]+\"", replace="simdutf8 = { version = \"{{version}}\"", exactly=1},
 ]
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,6 @@
 //! [dependencies]
 //! simdutf8 = "0.1.4"
 //! ```
-//! For ARM64 SIMD support on Rust 1.59:
-//! ```toml
-//! [dependencies]
-//! simdutf8 = { version = "0.1.4", features = ["aarch64_neon"] }
-//! ```
 //!
 //! Use [`basic::from_utf8()`] as a drop-in replacement for `std::str::from_utf8()`.
 //!
@@ -83,11 +78,7 @@
 //! for the SSE 4.2 implementation.
 //!
 //! ### ARM64
-//! To get the SIMD implementation with Rust 1.59 on ARM64 the crate feature `aarch64_neon` needs to be enabled. For Rust Nightly
-//! this is no longer required (but does not hurt either). Once [Rust PR #90621](https://github.com/rust-lang/rust/pull/90621)
-//! lands in a stable version, this is no longer required.
-//!
-//! CAVE: If this features is not turned on with Rust 1.59 the non-SIMD std library implementation is used.
+//! The SIMD implementation is used automatically since Rust 1.61.
 //!
 //! ### WASM32
 //! For wasm32 support, the implementation is selected at compile time based on the presence of the `simd128` target feature.


### PR DESCRIPTION
Update doc:
* aarch64 support is automatically enabled since Rust 1.61
* changelog
* update library doc from readme

Cargo release config:
* cargo-release: remove replacements that are no longer needed
* only allow releases from main branch