### PR TITLE
Clippy: remove outdated exceptions, warn instead of err, err in CI, clippy on windows, macos-x86_64 and wasm as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,6 @@ jobs:
         with:
           components: clippy
       - name: Clippy - all features enabled
-        run: cargo clippy --all-targets --all-features
+        run: RUSTFLAGS="-Dwarnings" cargo clippy --all-targets --all-features
       - name: Clippy - all features disabled
-        run: cargo clippy --all-targets --no-default-features
+        run: RUSTFLAGS="-Dwarnings" cargo clippy --all-targets --no-default-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,5 +209,9 @@ jobs:
           components: clippy
       - name: Clippy - all features enabled
         run: RUSTFLAGS="-Dwarnings" cargo clippy --all-targets --all-features
+        env:
+          RUSTFLAGS: "-D warnings"
       - name: Clippy - all features disabled
         run: RUSTFLAGS="-Dwarnings" cargo clippy --all-targets --no-default-features
+        env:
+          RUSTFLAGS: "-D warnings"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,10 +208,10 @@ jobs:
         with:
           components: clippy
       - name: Clippy - all features enabled
-        run: RUSTFLAGS="-Dwarnings" cargo clippy --all-targets --all-features
+        run: cargo clippy --all-targets --all-features
         env:
           RUSTFLAGS: "-D warnings"
       - name: Clippy - all features disabled
-        run: RUSTFLAGS="-Dwarnings" cargo clippy --all-targets --no-default-features
+        run: cargo clippy --all-targets --no-default-features
         env:
           RUSTFLAGS: "-D warnings"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -91,3 +91,23 @@ jobs:
         run: cargo build --no-default-features ${{ matrix.features }} --target ${{ matrix.target }} --verbose
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
+
+  clippy_check:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest, macos-13]
+        target: [wasm32-wasi, wasm32-unknown-unknown]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: clippy
+      - name: Clippy - all features enabled
+        run: cargo clippy --target ${{ matrix.target }} --all-targets --all-features
+        env:
+          RUSTFLAGS: "-D warnings"
+      - name: Clippy - all features disabled
+        run: cargo clippy --target ${{ matrix.target }} --all-targets --no-default-features
+        env:
+          RUSTFLAGS: "-D warnings"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -103,6 +103,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
+          targets: ${{ matrix.target }}
       - name: Clippy - all features enabled
         run: cargo clippy --target ${{ matrix.target }} --all-targets --all-features
         env:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,6 @@
 )]
 #![allow(clippy::redundant_pub_crate)] // check is broken
 #![allow(clippy::redundant_else)] // can make code more readable
-#![allow(clippy::explicit_iter_loop)] // can make code more readable
-#![allow(clippy::semicolon_if_nothing_returned)] // see https://github.com/rust-lang/rust-clippy/issues/7768
 #![allow(clippy::missing_const_for_fn)] // not necessary most of the times
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![warn(unused_extern_crates)]
-#![deny(
+#![warn(
     clippy::all,
     clippy::unwrap_used,
     clippy::unnecessary_unwrap,


### PR DESCRIPTION
tbd
* clippy wasm
* allow->expect where possible