### PR TITLE
Fix: custom memcpy fn was not inlined if `public_imp` feature was enabled

### DIFF
--- a/src/implementation/helpers.rs
+++ b/src/implementation/helpers.rs
@@ -38,6 +38,7 @@ pub(crate) fn get_compat_error(input: &[u8], failing_block_pos: usize) -> Utf8Er
 }
 
 #[allow(dead_code)]
+#[inline]
 pub(crate) unsafe fn memcpy_unaligned_nonoverlapping_inline_opt_lt_64(
     mut src: *const u8,
     mut dest: *mut u8,


### PR DESCRIPTION
Fixes #99 