### PR TITLE
Remove CI dependency on cargo asm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  INLINE_IGNORE_PATTERN: "drop_in_place|::fmt::"
 
 jobs:
   test:
@@ -69,21 +68,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
-      - name: Install cargo-asm
-        run: cargo install cargo-asm
-      - uses: dtolnay/rust-toolchain@master
-        with:
           toolchain: ${{ matrix.toolchain }}
-      - name: Set default toolchain
-        run: rustup default ${{ matrix.toolchain }}
       - name: Check if the expected fns are inlined
         run: |
-          cargo clean;cargo asm|egrep -v $INLINE_IGNORE_PATTERN|diff -u expected-methods-x86-std.txt -
-          cargo clean;RUSTFLAGS="-C target-feature=+avx2" cargo asm|egrep -v $INLINE_IGNORE_PATTERN|diff -u expected-methods-x86-std-avx2.txt -
-          cargo clean;cargo asm --no-default-features|egrep -v $INLINE_IGNORE_PATTERN|diff -u empty.txt -
-          cargo clean;RUSTFLAGS="-C target-feature=+avx2" cargo asm --no-default-features|egrep -v $INLINE_IGNORE_PATTERN|diff -u expected-methods-x86-nostd-avx2.txt -
-          cargo clean;RUSTFLAGS="-C target-feature=+sse4.2" cargo asm --no-default-features|egrep -v $INLINE_IGNORE_PATTERN|diff -u expected-methods-x86-nostd-sse42.txt -
+          ./check-inlining.sh expected-methods-x86-std.txt
+          RUSTFLAGS="-C target-feature=+avx2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std-avx2.txt
+          ./check-inlining.sh x86_64-unknown-linux-gnu empty.txt "--no-default-features"
+          RUSTFLAGS="-C target-feature=+avx2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-nostd-avx2.txt "--no-default-features"
+          RUSTFLAGS="-C target-feature=+sse4.2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-nostd-sse42.txt "--no-default-features"
 
   test-inlining-aarch64-enabled-by-default:
     runs-on: ubuntu-latest, macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,10 @@ jobs:
       - name: Check if the expected fns are inlined
         run: |
           ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std.txt
+          ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std.txt --features public_imp
           RUSTFLAGS="-C target-feature=+avx2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std-avx2.txt
-          RUSTFLAGS="-C target-feature=+avx2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-nostd-avx2.txt "--no-default-features"
-          RUSTFLAGS="-C target-feature=+sse4.2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-nostd-sse42.txt "--no-default-features"
+          RUSTFLAGS="-C target-feature=+avx2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-nostd-avx2.txt --no-default-features
+          RUSTFLAGS="-C target-feature=+sse4.2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-nostd-sse42.txt --no-default-features
 
   test-inlining-aarch64-enabled-by-default:
     runs-on: macos-latest
@@ -103,7 +104,8 @@ jobs:
       - name: Check if the expected fns are inlined
         run: |
           ./check-inlining.sh ${{ matrix.target }} expected-methods-aarch64-neon.txt
-          ./check-inlining.sh ${{ matrix.target }} expected-methods-aarch64-neon.txt "--no-default-features"
+          ./check-inlining.sh ${{ matrix.target }} expected-methods-aarch64-neon.txt --no-default-features
+          ./check-inlining.sh ${{ matrix.target }} expected-methods-aarch64-neon.txt --features public_imp
 
   test-doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - name: Check if the expected fns are inlined
         run: |
-          ./check-inlining.sh expected-methods-x86-std.txt
+          ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std.txt
           RUSTFLAGS="-C target-feature=+avx2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std-avx2.txt
           ./check-inlining.sh x86_64-unknown-linux-gnu empty.txt "--no-default-features"
           RUSTFLAGS="-C target-feature=+avx2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-nostd-avx2.txt "--no-default-features"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,6 @@ jobs:
         run: |
           ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std.txt
           RUSTFLAGS="-C target-feature=+avx2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std-avx2.txt
-          ./check-inlining.sh x86_64-unknown-linux-gnu empty.txt "--no-default-features"
           RUSTFLAGS="-C target-feature=+avx2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-nostd-avx2.txt "--no-default-features"
           RUSTFLAGS="-C target-feature=+sse4.2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-nostd-sse42.txt "--no-default-features"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Check if the expected fns are inlined
         run: |
           ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std.txt
-          ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std.txt --features public_imp
+          ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std.txt "--features public_imp""
           RUSTFLAGS="-C target-feature=+avx2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std-avx2.txt
           RUSTFLAGS="-C target-feature=+avx2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-nostd-avx2.txt --no-default-features
           RUSTFLAGS="-C target-feature=+sse4.2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-nostd-sse42.txt --no-default-features
@@ -105,7 +105,7 @@ jobs:
         run: |
           ./check-inlining.sh ${{ matrix.target }} expected-methods-aarch64-neon.txt
           ./check-inlining.sh ${{ matrix.target }} expected-methods-aarch64-neon.txt --no-default-features
-          ./check-inlining.sh ${{ matrix.target }} expected-methods-aarch64-neon.txt --features public_imp
+          ./check-inlining.sh ${{ matrix.target }} expected-methods-aarch64-neon.txt "--features public_imp""
 
   test-doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
+      - name: Install stable toolchain
+        run: rustup toolchain add stable
+      - name: Install rustfilt
+        run: cargo +stable install rustfilt
       - name: Check if the expected fns are inlined
         run: |
           ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std.txt
@@ -96,7 +100,7 @@ jobs:
       - name: Install stable toolchain
         run: rustup toolchain add stable
       - name: Install rustfilt
-        run: cargo install rustfilt
+        run: cargo +stable install rustfilt
       - name: Check if the expected fns are inlined
         run: |
           ./check-inlining.sh ${{ matrix.target }} expected-methods-aarch64-neon.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,11 @@ jobs:
           cargo clean;RUSTFLAGS="-C target-feature=+sse4.2" cargo asm --no-default-features|egrep -v $INLINE_IGNORE_PATTERN|diff -u expected-methods-x86-nostd-sse42.txt -
 
   test-inlining-aarch64-enabled-by-default:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest, macos-latest
     strategy:
       matrix:
-        toolchain: [nightly, beta, stable]
+        # the neon target feature was unconditionally enabled for aarch64 in 1.61.0
+        toolchain: [nightly, beta, stable, 1.61.0]
         target: [aarch64-unknown-linux-gnu, aarch64-apple-darwin]
     defaults:
       run:
@@ -100,14 +101,14 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           targets: ${{ matrix.target }}
-      - name: Install cargo-asm
-        run: cargo install cargo-asm
+      - name: Install stable toolchain
+        run: rustup toolchain add stable
+      - name: Install rustfilt
+        run: cargo install rustfilt
       - name: Check if the expected fns are inlined
         run: |
-          cargo clean;cargo asm --target ${{ matrix.target }} --features aarch64_neon|egrep -v $INLINE_IGNORE_PATTERN|diff -u expected-methods-aarch64-neon.txt -
-          cargo clean;cargo asm --target ${{ matrix.target }} --no-default-features --features aarch64_neon|egrep -v $INLINE_IGNORE_PATTERN|diff -u expected-methods-aarch64-neon.txt -
-          cargo clean;cargo asm --target ${{ matrix.target }}|egrep -v $INLINE_IGNORE_PATTERN|diff -u expected-methods-aarch64-neon.txt -
-          cargo clean;cargo asm --target ${{ matrix.target }} --no-default-features|egrep -v $INLINE_IGNORE_PATTERN|diff -u expected-methods-aarch64-neon.txt -
+          ./check-inlining.sh ${{ matrix.target }} expected-methods-aarch64-neon.txt
+          ./check-inlining.sh ${{ matrix.target }} expected-methods-aarch64-neon.txt "--no-default-features"
 
   test-doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           RUSTFLAGS="-C target-feature=+sse4.2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-nostd-sse42.txt "--no-default-features"
 
   test-inlining-aarch64-enabled-by-default:
-    runs-on: ubuntu-latest, macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         # the neon target feature was unconditionally enabled for aarch64 in 1.61.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Check if the expected fns are inlined
         run: |
           ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std.txt
-          ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std.txt "--features public_imp""
+          ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std.txt "--features public_imp"
           RUSTFLAGS="-C target-feature=+avx2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-std-avx2.txt
           RUSTFLAGS="-C target-feature=+avx2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-nostd-avx2.txt --no-default-features
           RUSTFLAGS="-C target-feature=+sse4.2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-nostd-sse42.txt --no-default-features
@@ -105,7 +105,7 @@ jobs:
         run: |
           ./check-inlining.sh ${{ matrix.target }} expected-methods-aarch64-neon.txt
           ./check-inlining.sh ${{ matrix.target }} expected-methods-aarch64-neon.txt --no-default-features
-          ./check-inlining.sh ${{ matrix.target }} expected-methods-aarch64-neon.txt "--features public_imp""
+          ./check-inlining.sh ${{ matrix.target }} expected-methods-aarch64-neon.txt "--features public_imp"
 
   test-doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           RUSTFLAGS="-C target-feature=+sse4.2" ./check-inlining.sh x86_64-unknown-linux-gnu expected-methods-x86-nostd-sse42.txt "--no-default-features"
 
   test-inlining-aarch64-enabled-by-default:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
         # the neon target feature was unconditionally enabled for aarch64 in 1.61.0

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -68,6 +68,7 @@ jobs:
         run: |
           ./check-inlining.sh ${{ matrix.target }} expected-methods-wasm32-simd128.txt
           ./check-inlining.sh ${{ matrix.target }} expected-methods-wasm32-simd128.txt --no-default-features
+          ./check-inlining.sh ${{ matrix.target }} expected-methods-wasm32-simd128.txt --features public_imp
   cross-build-wasm32-unknown:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -61,12 +61,11 @@ jobs:
       - name: Install cargo-asm
         run: cargo install cargo-asm
       - name: Check if the expected fns are inlined
+        env:
+          RUSTFLAGS: "-C target-feature=+simd128"
         run: |
-          cargo clean;RUSTFLAGS="-C target-feature=+simd128" cargo asm --target ${{ matrix.target }}|egrep -v $INLINE_IGNORE_PATTERN|diff -u expected-methods-wasm32-simd128.txt -
-          cargo clean;RUSTFLAGS="-C target-feature=+simd128" cargo asm --target ${{ matrix.target }} --no-default-features|egrep -v $INLINE_IGNORE_PATTERN|diff -u expected-methods-wasm32-simd128.txt -
-          cargo clean;cargo asm --target ${{ matrix.target }}|egrep -v $INLINE_IGNORE_PATTERN|diff -u empty.txt -
-          cargo clean;cargo asm --target ${{ matrix.target }} --no-default-features|egrep -v $INLINE_IGNORE_PATTERN|diff -u empty.txt -
-
+          ./check-inlining.sh {{ matrix.target }} expected-methods-wasm32-simd128.txt
+          ./check-inlining.sh {{ matrix.target }} expected-methods-wasm32-simd128.txt --no-default-features
   cross-build-wasm32-unknown:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -58,8 +58,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           targets: ${{ matrix.target }}
-      - name: Install cargo-asm
-        run: cargo install cargo-asm
       - name: Check if the expected fns are inlined
         env:
           RUSTFLAGS: "-C target-feature=+simd128"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           ./check-inlining.sh ${{ matrix.target }} expected-methods-wasm32-simd128.txt
           ./check-inlining.sh ${{ matrix.target }} expected-methods-wasm32-simd128.txt --no-default-features
-          ./check-inlining.sh ${{ matrix.target }} expected-methods-wasm32-simd128.txt "--features public_imp""
+          ./check-inlining.sh ${{ matrix.target }} expected-methods-wasm32-simd128.txt "--features public_imp"
   cross-build-wasm32-unknown:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -62,8 +62,8 @@ jobs:
         env:
           RUSTFLAGS: "-C target-feature=+simd128"
         run: |
-          ./check-inlining.sh {{ matrix.target }} expected-methods-wasm32-simd128.txt
-          ./check-inlining.sh {{ matrix.target }} expected-methods-wasm32-simd128.txt --no-default-features
+          ./check-inlining.sh ${{ matrix.target }} expected-methods-wasm32-simd128.txt
+          ./check-inlining.sh ${{ matrix.target }} expected-methods-wasm32-simd128.txt --no-default-features
   cross-build-wasm32-unknown:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -58,6 +58,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           targets: ${{ matrix.target }}
+      - name: Install stable toolchain
+        run: rustup toolchain add stable
+      - name: Install rustfilt
+        run: cargo +stable install rustfilt
       - name: Check if the expected fns are inlined
         env:
           RUSTFLAGS: "-C target-feature=+simd128"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           ./check-inlining.sh ${{ matrix.target }} expected-methods-wasm32-simd128.txt
           ./check-inlining.sh ${{ matrix.target }} expected-methods-wasm32-simd128.txt --no-default-features
-          ./check-inlining.sh ${{ matrix.target }} expected-methods-wasm32-simd128.txt --features public_imp
+          ./check-inlining.sh ${{ matrix.target }} expected-methods-wasm32-simd128.txt "--features public_imp""
   cross-build-wasm32-unknown:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -46,7 +46,7 @@ jobs:
           WASM_RUNNER_VERBOSE: 1
 
   test-inlining-wasm32:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
         target: [wasm32-wasi, wasm32-unknown-unknown]

--- a/bench/BENCHMARKING.md
+++ b/bench/BENCHMARKING.md
@@ -51,9 +51,10 @@ variable to your installation for it to be found (e.g., `LLVM_SYS_120_PREFIX` at
 * Optional: disable hyper-threading (not sure if necessary, my test machine has no hyper threading)
 
 ### Factors affecting performance
-* missed inlining plays a huge role of course, unfortunately one can not use `#[inline(always)] on
-* functions with `#[target_feature(enable = "...")]` and even though that would only be strong a hint.
-  What is needed is an error on non-inlining. Simulating that using [cargo asm](https://github.com/gnzlbg/cargo-asm) to make sure that methods supposed to be inlined do not exist in the rlib.
+* missed inlining plays a huge role of course, unfortunately one can not use `#[inline(always)]` on
+  functions with `#[target_feature(enable = "...")]` and even though that would only be strong a hint.
+  What is needed is an error on non-inlining. This can be checked with `nm` on the rlib or with tools
+  like cargo-show-asm.
 * alignment plays a huge role on some machines (modern Intel, modern AMD not so much)
   * up to 20% better performance on long but unaligned slices (which are apparently likely at least on Linux)
 

--- a/inlining/check-inlining.sh
+++ b/inlining/check-inlining.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-INLINE_IGNORE_PATTERN='drop_in_place|::fmt::|^\$x\.'
-
 target="$1"
 expected_fns="$2"
 build_args="${3:-}"
@@ -16,5 +14,5 @@ else
     pattern=" (t|T) "
     cut_arg=20
 fi
-
-echo "$nm_output" | rustfilt | egrep "$pattern" | cut -c "$cut_arg"- | grep -Ev $INLINE_IGNORE_PATTERN | sort | diff -u $expected_fns -
+inline_ignore_pattern='drop_in_place|::fmt::|^\$x\.|^<T as core::convert::From<T>>::from$'
+echo "$nm_output" | rustfilt | egrep "$pattern" | cut -c "$cut_arg"- | grep -Ev "$inline_ignore_pattern" | sort | diff -u $expected_fns -

--- a/inlining/check-inlining.sh
+++ b/inlining/check-inlining.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-INLINE_IGNORE_PATTERN="drop_in_place|::fmt::"
+INLINE_IGNORE_PATTERN='drop_in_place|::fmt::|^\$x\.'
 
 target="$1"
 expected_fns="$2"

--- a/inlining/check-inlining.sh
+++ b/inlining/check-inlining.sh
@@ -3,11 +3,6 @@ set -euo pipefail
 
 INLINE_IGNORE_PATTERN="drop_in_place|::fmt::"
 
-if [ "$#" -ne 2 ]; then
-    echo "Usage: $0 <target> <build_args>"
-    exit 1
-fi
-
 target="$1"
 expected_fns="$2"
 build_args="${3:-}"
@@ -22,4 +17,4 @@ else
     cut_arg=20
 fi
 
-echo "$nm_output" | rustfilt | egrep "$pattern" | cut -c "$cut_arg"- | grep -Ev $INLINE_IGNORE_PATTERN | diff -u $expected_fns -
+echo "$nm_output" | rustfilt | egrep "$pattern" | cut -c "$cut_arg"- | grep -Ev $INLINE_IGNORE_PATTERN | sort | diff -u $expected_fns -

--- a/inlining/check-inlining.sh
+++ b/inlining/check-inlining.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INLINE_IGNORE_PATTERN="drop_in_place|::fmt::"
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <target> <build_args>"
+    exit 1
+fi
+
+target="$1"
+expected_fns="$2"
+build_args="${3:-}"
+cargo clean --quiet
+cargo build --quiet --release --target $target $build_args
+nm_output=$(nm -U ../target/$target/release/libsimdutf8.rlib 2>/dev/null)
+echo "$nm_output" | rustfilt | egrep " (t|T) _" | cut -c 21- | grep -Ev $INLINE_IGNORE_PATTERN | diff -u $expected_fns -

--- a/inlining/check-inlining.sh
+++ b/inlining/check-inlining.sh
@@ -8,7 +8,7 @@ expected_fns="$2"
 build_args="${3:-}"
 cargo clean --quiet
 cargo build --quiet --release --target $target $build_args
-nm_output=$(nm -U ../target/$target/release/libsimdutf8.rlib 2>/dev/null)
+nm_output=$(nm --defined-only ../target/$target/release/libsimdutf8.rlib)
 if [[ $target == *darwin* ]]; then
     pattern=" (t|T) _"
     cut_arg=21

--- a/inlining/check-inlining.sh
+++ b/inlining/check-inlining.sh
@@ -14,4 +14,12 @@ build_args="${3:-}"
 cargo clean --quiet
 cargo build --quiet --release --target $target $build_args
 nm_output=$(nm -U ../target/$target/release/libsimdutf8.rlib 2>/dev/null)
-echo "$nm_output" | rustfilt | egrep " (t|T) _" | cut -c 21- | grep -Ev $INLINE_IGNORE_PATTERN | diff -u $expected_fns -
+if [[ $target == *darwin* ]]; then
+    pattern=" (t|T) _"
+    cut_arg=21
+else
+    pattern=" (t|T) "
+    cut_arg=20
+fi
+
+echo "$nm_output" | rustfilt | egrep "$pattern" | cut -c "$cut_arg"- | grep -Ev $INLINE_IGNORE_PATTERN | diff -u $expected_fns -

--- a/inlining/expected-methods-wasm32-simd128.txt
+++ b/inlining/expected-methods-wasm32-simd128.txt
@@ -1,3 +1,3 @@
-simdutf8::implementation::helpers::get_compat_error
-simdutf8::implementation::wasm32::validate_utf8_basic_simd128
-simdutf8::implementation::wasm32::validate_utf8_compat_simd128
+::implementation::helpers::get_compat_error
+::implementation::wasm32::validate_utf8_basic_simd128
+::implementation::wasm32::validate_utf8_compat_simd128

--- a/inlining/expected-methods-x86-std.txt
+++ b/inlining/expected-methods-x86-std.txt
@@ -5,7 +5,5 @@ simdutf8::implementation::x86::avx2::validate_utf8_basic
 simdutf8::implementation::x86::avx2::validate_utf8_compat
 simdutf8::implementation::x86::sse42::validate_utf8_basic
 simdutf8::implementation::x86::sse42::validate_utf8_compat
-simdutf8::implementation::x86::validate_utf8_basic::FN
 simdutf8::implementation::x86::validate_utf8_basic::get_fastest
-simdutf8::implementation::x86::validate_utf8_compat::FN
 simdutf8::implementation::x86::validate_utf8_compat::get_fastest

--- a/src/implementation/helpers.rs
+++ b/src/implementation/helpers.rs
@@ -38,6 +38,7 @@ pub(crate) fn get_compat_error(input: &[u8], failing_block_pos: usize) -> Utf8Er
 }
 
 #[allow(dead_code)]
+#[inline]
 pub(crate) unsafe fn memcpy_unaligned_nonoverlapping_inline_opt_lt_64(
     mut src: *const u8,
     mut dest: *mut u8,


### PR DESCRIPTION
cargo asm also lists fns compiled for the host via proc-macros. That does not make sense for the inlining check.

Also fixes #99.