### PR TITLE
wasm32-wasi -> wasm32-wasip1

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -13,7 +13,7 @@ env:
   INLINE_IGNORE_PATTERN: "drop_in_place|::fmt::"
 
 jobs:
-  test-wasm32-wasi:
+  test-wasm32-wasip1:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -27,7 +27,7 @@ jobs:
             "--features std,public_imp",
           ]
         rustflags: ["-D warnings", "-D warnings -C target-feature=+simd128"]
-        target: [wasm32-wasi]
+        target: [wasm32-wasip1]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -49,7 +49,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        target: [wasm32-wasi, wasm32-unknown-unknown]
+        target: [wasm32-wasip1, wasm32-unknown-unknown]
     defaults:
       run:
         working-directory: inlining
@@ -58,10 +58,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           targets: ${{ matrix.target }}
-      - name: Install stable toolchain
-        run: rustup toolchain add stable
       - name: Install rustfilt
-        run: cargo +stable install rustfilt
+        run: cargo install rustfilt
       - name: Check if the expected fns are inlined
         env:
           RUSTFLAGS: "-C target-feature=+simd128"
@@ -99,7 +97,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest, macos-13]
-        target: [wasm32-wasi, wasm32-unknown-unknown]
+        target: [wasm32-wasip1, wasm32-unknown-unknown]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -42,7 +42,7 @@ jobs:
         run: cargo test --no-default-features ${{ matrix.features }} --target ${{ matrix.target }} --all-targets --verbose
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
-          CARGO_TARGET_WASM32_WASI_RUNNER: wasm-runner wasmer
+          CARGO_TARGET_WASM32_WASIP1_RUNNER: wasm-runner wasmer
           WASM_RUNNER_VERBOSE: 1
 
   test-inlining-wasm32:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ hints = []
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-unknown-linux-gnu"
-targets = ["aarch64-unknown-linux-gnu", "wasm32-unknown-unknown", "wasm32-wasi"]
+targets = ["aarch64-unknown-linux-gnu", "wasm32-unknown-unknown", "wasm32-wasip1"]
 
 [dependencies]
 flexpect = "0.0.4"

--- a/wasm32-development.md
+++ b/wasm32-development.md
@@ -3,8 +3,8 @@
 Since there is no native host platform for WebAssembly, developing/targeting requires a bit more setup than a vanilla
 Rust toolchain environment.  To build/target this library outside a `wasm-pack` context, you can do the following:
 
-* Install toolchain with `wasm32-wasi` or `wasm32-unknown-unknown` (e.g. `rustup target add wasm32-wasi`).
-  * `wasm32-wasi` is a nice target because it gives us the capability to run the tests as-is with a WASM runtime.
+* Install toolchain with `wasm32-wasip1` or `wasm32-unknown-unknown` (e.g. `rustup target add wasm32-wasip1`).
+  * `wasm32-wasip1` is a nice target because it gives us the capability to run the tests as-is with a WASM runtime.
 * Install a WASM runtime (e.g. [Wasmer]/[Wasmtime]/[WAVM]).
 * Install `wasm-runner` a simple runner wrapper to run WASM targeted code with a WASM runtime:
 
@@ -16,7 +16,7 @@ $ cargo install wasm-runner
 
 ```
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"
 rustflags = "-C target-feature=+simd128"
 
 [target.'cfg(target_arch="wasm32")']
@@ -35,10 +35,10 @@ You can do this without configuration as well:
 ```
 $ RUSTFLAGS="-C target-feature=+simd128" \
     CARGO_TARGET_WASM32_WASI_RUNNER="wasm-runner wasmer" \
-    cargo test --target wasm32-wasi
+    cargo test --target wasm32-wasip1
 $ RUSTFLAGS="-C target-feature=+simd128" \
     CARGO_TARGET_WASM32_WASI_RUNNER="wasm-runner wasmer" \
-    cargo test --target wasm32-wasi --all-features
+    cargo test --target wasm32-wasip1 --all-features
 ```
 
 [wasmer]: https://wasmer.io/


### PR DESCRIPTION
warning: the `wasm32-wasi` target is being renamed to `wasm32-wasip1` and the `wasm32-wasi` target will be removed from nightly in October 2024 and removed from stable Rust in January 2025