### PR TITLE
Remove aarch64 NEON SIMD support for Rust 1.59 and Rust 1.60

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ std = []
 # expose SIMD implementations in basic::imp::* and compat::imp::*
 public_imp = []
 
-# aarch64 NEON SIMD implementation - only necessary for Rust 1.59 and Rust 1.60
+# deprecated - does not do anything
 aarch64_neon = []
 
 # enable aarch64 prefetching for minor speedup - requires nightly

--- a/src/basic.rs
+++ b/src/basic.rs
@@ -218,10 +218,7 @@ pub mod imp {
     }
 
     /// Includes the aarch64 SIMD implementations.
-    #[cfg(all(
-        target_arch = "aarch64",
-        any(feature = "aarch64_neon", target_feature = "neon")
-    ))]
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     pub mod aarch64 {
         /// Includes the Neon-based validation implementation for aarch64 CPUs.
         ///

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -116,10 +116,7 @@ pub mod imp {
     }
 
     /// Includes the aarch64 SIMD implementations.
-    #[cfg(all(
-        target_arch = "aarch64",
-        any(feature = "aarch64_neon", target_feature = "neon")
-    ))]
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     pub mod aarch64 {
         /// Includes the validation implementation for Neon SIMD.
         pub mod neon {

--- a/src/implementation/aarch64/mod.rs
+++ b/src/implementation/aarch64/mod.rs
@@ -1,8 +1,8 @@
-#[cfg(any(feature = "aarch64_neon", target_feature = "neon"))]
+#[cfg(target_feature = "neon")]
 pub(crate) mod neon;
 
 #[inline]
-#[cfg(any(feature = "aarch64_neon", target_feature = "neon"))]
+#[cfg(target_feature = "neon")]
 pub(crate) unsafe fn validate_utf8_basic(input: &[u8]) -> Result<(), crate::basic::Utf8Error> {
     if input.len() < super::helpers::SIMD_CHUNK_SIZE {
         return super::validate_utf8_basic_fallback(input);
@@ -12,16 +12,16 @@ pub(crate) unsafe fn validate_utf8_basic(input: &[u8]) -> Result<(), crate::basi
 }
 
 #[inline(never)]
-#[cfg(any(feature = "aarch64_neon", target_feature = "neon"))]
+#[cfg(target_feature = "neon")]
 unsafe fn validate_utf8_basic_neon(input: &[u8]) -> Result<(), crate::basic::Utf8Error> {
     neon::validate_utf8_basic(input)
 }
 
-#[cfg(not(any(feature = "aarch64_neon", target_feature = "neon")))]
+#[cfg(not(target_feature = "neon"))]
 pub(crate) use super::validate_utf8_basic_fallback as validate_utf8_basic;
 
 #[inline]
-#[cfg(any(feature = "aarch64_neon", target_feature = "neon"))]
+#[cfg(target_feature = "neon")]
 pub(crate) unsafe fn validate_utf8_compat(input: &[u8]) -> Result<(), crate::compat::Utf8Error> {
     if input.len() < super::helpers::SIMD_CHUNK_SIZE {
         return super::validate_utf8_compat_fallback(input);
@@ -31,10 +31,10 @@ pub(crate) unsafe fn validate_utf8_compat(input: &[u8]) -> Result<(), crate::com
 }
 
 #[inline(never)]
-#[cfg(any(feature = "aarch64_neon", target_feature = "neon"))]
+#[cfg(target_feature = "neon")]
 unsafe fn validate_utf8_compat_neon(input: &[u8]) -> Result<(), crate::compat::Utf8Error> {
     neon::validate_utf8_compat(input)
 }
 
-#[cfg(not(any(feature = "aarch64_neon", target_feature = "neon")))]
+#[cfg(not(target_feature = "neon"))]
 pub(crate) use super::validate_utf8_compat_fallback as validate_utf8_compat;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -91,10 +91,7 @@ mod public_imp {
                 );
             }
         }
-        #[cfg(all(
-            target_arch = "aarch64",
-            any(feature = "aarch64_neon", target_feature = "neon")
-        ))]
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
         unsafe {
             assert!(simdutf8::basic::imp::aarch64::neon::validate_utf8(input).is_ok());
             assert!(simdutf8::compat::imp::aarch64::neon::validate_utf8(input).is_ok());
@@ -166,10 +163,7 @@ mod public_imp {
                 );
             }
         }
-        #[cfg(all(
-            target_arch = "aarch64",
-            any(feature = "aarch64_neon", target_feature = "neon")
-        ))]
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
         unsafe {
             assert!(simdutf8::basic::imp::aarch64::neon::validate_utf8(input).is_err());
             let err = simdutf8::compat::imp::aarch64::neon::validate_utf8(input).unwrap_err();
@@ -300,10 +294,7 @@ mod public_imp {
 
     #[test]
     #[should_panic]
-    #[cfg(all(
-        target_arch = "aarch64",
-        any(feature = "aarch64_neon", target_feature = "neon")
-    ))]
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     fn test_neon_chunked_panic() {
         test_chunked_streaming_with_chunk_size::<
             simdutf8::basic::imp::aarch64::neon::ChunkedUtf8ValidatorImp,


### PR DESCRIPTION
Minimum version is now 1.61. The  non-SIMD `std` implementation will be used on Rust 1.59 - 1.60.