### PR TITLE
made const both `Utf8Error` methods

### DIFF
--- a/src/compat.rs
+++ b/src/compat.rs
@@ -32,7 +32,7 @@ impl Utf8Error {
     /// ...
     #[inline]
     #[must_use]
-    pub fn valid_up_to(&self) -> usize {
+    pub const fn valid_up_to(&self) -> usize {
         self.valid_up_to
     }
 
@@ -41,8 +41,12 @@ impl Utf8Error {
     /// ...
     #[inline]
     #[must_use]
-    pub fn error_len(&self) -> Option<usize> {
-        self.error_len.map(|len| len as usize)
+    pub const fn error_len(&self) -> Option<usize> {
+        if let Some(len) = self.error_len {
+            Some(len as usize)
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
This was missing for total compatibility with core's.
