### PR TITLE
fix UB in a pointer addition

### DIFF
--- a/src/implementation/algorithm.rs
+++ b/src/implementation/algorithm.rs
@@ -232,7 +232,7 @@ macro_rules! algorithm_simd {
 
             while idx < iter_lim {
                 if PREFETCH {
-                    simd_prefetch(input.as_ptr().add(idx + SIMD_CHUNK_SIZE * 2));
+                    simd_prefetch(input.as_ptr().wrapping_add(idx + SIMD_CHUNK_SIZE * 2));
                 }
                 let input = SimdInput::new(input.as_ptr().add(idx));
                 algorithm.check_utf8(input);
@@ -301,7 +301,7 @@ macro_rules! algorithm_simd {
                 } else {
                     while idx < iter_lim {
                         if PREFETCH {
-                            simd_prefetch(input.as_ptr().add(idx + SIMD_CHUNK_SIZE * 2));
+                            simd_prefetch(input.as_ptr().wrapping_add(idx + SIMD_CHUNK_SIZE * 2));
                         }
                         let simd_input = SimdInput::new(input.as_ptr().add(idx));
                         if simd_input.is_ascii() {


### PR DESCRIPTION
A `ptr.add(...)` asserts that the pointer is valid at construction; `wrapping_add` defers that until actual use, and the prefetch intrinsic is kind of special in that it does not truly load from the pointer. So, using `wrapping_add` makes miri happy