### PR TITLE
DRY - move must_be_2_3_continuation back into algorithm

### DIFF
--- a/src/implementation/aarch64/neon.rs
+++ b/src/implementation/aarch64/neon.rs
@@ -203,15 +203,6 @@ impl From<uint8x16_t> for SimdU8Value {
     }
 }
 
-impl Utf8CheckAlgorithm<SimdU8Value> {
-    #[inline]
-    unsafe fn must_be_2_3_continuation(prev2: SimdU8Value, prev3: SimdU8Value) -> SimdU8Value {
-        let is_third_byte = prev2.saturating_sub(SimdU8Value::splat(0xe0 - 0x80));
-        let is_fourth_byte = prev3.saturating_sub(SimdU8Value::splat(0xf0 - 0x80));
-        is_third_byte.or(is_fourth_byte)
-    }
-}
-
 #[inline]
 #[cfg(feature = "aarch64_neon_prefetch")]
 unsafe fn simd_prefetch(ptr: *const u8) {

--- a/src/implementation/algorithm.rs
+++ b/src/implementation/algorithm.rs
@@ -138,6 +138,14 @@ macro_rules! algorithm_simd {
 
             $(#[$feat])*
             #[inline]
+            unsafe fn must_be_2_3_continuation(prev2: SimdU8Value, prev3: SimdU8Value) -> SimdU8Value {
+                let is_third_byte = prev2.saturating_sub(SimdU8Value::splat(0xe0 - 0x80));
+                let is_fourth_byte = prev3.saturating_sub(SimdU8Value::splat(0xf0 - 0x80));
+                is_third_byte.or(is_fourth_byte)
+            }
+
+            $(#[$feat])*
+            #[inline]
             unsafe fn check_multibyte_lengths(
                 input: SimdU8Value,
                 prev: SimdU8Value,

--- a/src/implementation/armv7/neon.rs
+++ b/src/implementation/armv7/neon.rs
@@ -237,16 +237,6 @@ impl From<uint8x16_t> for SimdU8Value {
     }
 }
 
-impl Utf8CheckAlgorithm<SimdU8Value> {
-    #[inline]
-    #[target_feature(enable = "neon")]
-    unsafe fn must_be_2_3_continuation(prev2: SimdU8Value, prev3: SimdU8Value) -> SimdU8Value {
-        let is_third_byte = prev2.saturating_sub(SimdU8Value::splat(0xe0 - 0x80));
-        let is_fourth_byte = prev3.saturating_sub(SimdU8Value::splat(0xf0 - 0x80));
-        is_third_byte.or(is_fourth_byte)
-    }
-}
-
 #[inline]
 unsafe fn simd_prefetch(_ptr: *const u8) {}
 

--- a/src/implementation/portable/simd128.rs
+++ b/src/implementation/portable/simd128.rs
@@ -202,15 +202,6 @@ impl From<u8x16> for SimdU8Value {
     }
 }
 
-impl Utf8CheckAlgorithm<SimdU8Value> {
-    #[inline]
-    fn must_be_2_3_continuation(prev2: SimdU8Value, prev3: SimdU8Value) -> SimdU8Value {
-        let is_third_byte = prev2.saturating_sub(SimdU8Value::splat(0xe0 - 0x80));
-        let is_fourth_byte = prev3.saturating_sub(SimdU8Value::splat(0xf0 - 0x80));
-        is_third_byte.or(is_fourth_byte)
-    }
-}
-
 #[inline]
 unsafe fn simd_prefetch(_ptr: *const u8) {}
 

--- a/src/implementation/portable/simd256.rs
+++ b/src/implementation/portable/simd256.rs
@@ -207,15 +207,6 @@ impl From<u8x32> for SimdU8Value {
     }
 }
 
-impl Utf8CheckAlgorithm<SimdU8Value> {
-    #[inline]
-    fn must_be_2_3_continuation(prev2: SimdU8Value, prev3: SimdU8Value) -> SimdU8Value {
-        let is_third_byte = prev2.saturating_sub(SimdU8Value::splat(0xe0 - 0x80));
-        let is_fourth_byte = prev3.saturating_sub(SimdU8Value::splat(0xf0 - 0x80));
-        is_third_byte.or(is_fourth_byte)
-    }
-}
-
 #[inline]
 unsafe fn simd_prefetch(_ptr: *const u8) {}
 

--- a/src/implementation/wasm32/simd128.rs
+++ b/src/implementation/wasm32/simd128.rs
@@ -246,15 +246,6 @@ impl From<v128> for SimdU8Value {
     }
 }
 
-impl Utf8CheckAlgorithm<SimdU8Value> {
-    #[inline]
-    unsafe fn must_be_2_3_continuation(prev2: SimdU8Value, prev3: SimdU8Value) -> SimdU8Value {
-        let is_third_byte = prev2.saturating_sub(SimdU8Value::splat(0xe0 - 0x80));
-        let is_fourth_byte = prev3.saturating_sub(SimdU8Value::splat(0xf0 - 0x80));
-        is_third_byte.or(is_fourth_byte)
-    }
-}
-
 #[inline]
 const fn simd_prefetch(_ptr: *const u8) {
     // no-op

--- a/src/implementation/x86/avx2.rs
+++ b/src/implementation/x86/avx2.rs
@@ -230,16 +230,6 @@ impl From<__m256i> for SimdU8Value {
     }
 }
 
-impl Utf8CheckAlgorithm<SimdU8Value> {
-    #[target_feature(enable = "avx2")]
-    #[inline]
-    unsafe fn must_be_2_3_continuation(prev2: SimdU8Value, prev3: SimdU8Value) -> SimdU8Value {
-        let is_third_byte = prev2.saturating_sub(SimdU8Value::splat(0xe0 - 0x80));
-        let is_fourth_byte = prev3.saturating_sub(SimdU8Value::splat(0xf0 - 0x80));
-        is_third_byte.or(is_fourth_byte)
-    }
-}
-
 #[target_feature(enable = "avx2")]
 #[inline]
 unsafe fn simd_prefetch(ptr: *const u8) {

--- a/src/implementation/x86/avx512.rs
+++ b/src/implementation/x86/avx512.rs
@@ -253,16 +253,6 @@ impl From<__m512i> for SimdU8Value {
     }
 }
 
-impl Utf8CheckAlgorithm<SimdU8Value> {
-    #[target_feature(enable = "avx512f,avx512bw,avx512vbmi")]
-    #[inline]
-    unsafe fn must_be_2_3_continuation(prev2: SimdU8Value, prev3: SimdU8Value) -> SimdU8Value {
-        let is_third_byte = prev2.saturating_sub(SimdU8Value::splat(0xe0 - 0x80));
-        let is_fourth_byte = prev3.saturating_sub(SimdU8Value::splat(0xf0 - 0x80));
-        is_third_byte.or(is_fourth_byte)
-    }
-}
-
 #[target_feature(enable = "avx512f,avx512bw,avx512vbmi")]
 #[inline]
 unsafe fn simd_prefetch(ptr: *const u8) {

--- a/src/implementation/x86/sse42.rs
+++ b/src/implementation/x86/sse42.rs
@@ -215,16 +215,6 @@ impl From<__m128i> for SimdU8Value {
     }
 }
 
-impl Utf8CheckAlgorithm<SimdU8Value> {
-    #[target_feature(enable = "sse4.2")]
-    #[inline]
-    unsafe fn must_be_2_3_continuation(prev2: SimdU8Value, prev3: SimdU8Value) -> SimdU8Value {
-        let is_third_byte = prev2.saturating_sub(SimdU8Value::splat(0xe0 - 0x80));
-        let is_fourth_byte = prev3.saturating_sub(SimdU8Value::splat(0xf0 - 0x80));
-        is_third_byte.or(is_fourth_byte)
-    }
-}
-
 #[target_feature(enable = "sse4.2")]
 #[inline]
 unsafe fn simd_prefetch(ptr: *const u8) {


### PR DESCRIPTION
It is identical for all implementations again after the recent optimization,.